### PR TITLE
fix: remove workaround that caused regression in complex cases; no lo…

### DIFF
--- a/src/shared/types/cml-constraint.ts
+++ b/src/shared/types/cml-constraint.ts
@@ -265,7 +265,7 @@ export class CmlConstraint extends AnnotatedCmlElement {
         }
 
         output += 'message(';
-        output += this.#declaration + ' == true';
+        output += this.#declaration;
         if (this.#explanation) {
           output += `, ${this.#explanation}`;
         }


### PR DESCRIPTION
…nger needed

W-19610166 - fix for cml convert prod-cfg-rules command creating incorrect message rules when ! (not) condition is implied, for example:
` message(productscopedesktop_criteria_1 && !(Windows_Processor == "Intel Core i9 5.2 GHz") == true, "Validate: Validated i9 Is selected.", "Info");`
should be:
` message(productscopedesktop_criteria_1 && !(Windows_Processor == "Intel Core i9 5.2 GHz"), "Validate: Validated i9 Is selected.", "Info");`