### PR TITLE
W-19618832: use attribute developer name in rule generation instead of attr name

### DIFF
--- a/src/shared/bre-rules-generator.ts
+++ b/src/shared/bre-rules-generator.ts
@@ -275,21 +275,24 @@ function handleHideDisableAttributeValueAction(
   { actionParameters, actionType, sequence }: RuleAction,
   rule: ConfiguratorRuleInput
 ): void {
-  for (const { attributeId: targetAttributeId, attributeName: targetAttributeName, values: targetAttributeValues } of (
+  for (const { attributeId: targetAttributeId, values: targetAttributeValues } of (
     actionParameters ?? []
   ).filter(({ type }) => type === 'Attribute')) {
-    if (targetAttributeId && targetAttributeName) {
-      const constraint = CmlConstraint.createRuleConstraint(
-        declaration,
-        actionType === 'HideAttributeValue' ? 'Hide' : 'Disable',
-        'attribute',
-        targetAttributeName,
-        'value',
-        targetAttributeValues
-      );
-      const sequenceValue = (rule.sequence ?? 0) + (sequence ?? 0);
-      constraint.setProperties({ sequence: sequenceValue });
-      (parentTargetType ?? targetType).addConstraint(constraint);
+    if (targetAttributeId) {
+      const targetAttribute = targetType.findAttributeById(targetAttributeId);
+      if (targetAttribute) {
+        const constraint = CmlConstraint.createRuleConstraint(
+          declaration,
+          actionType === 'HideAttributeValue' ? 'Hide' : 'Disable',
+          'attribute',
+          targetAttribute.name,
+          'value',
+          targetAttributeValues
+        );
+        const sequenceValue = (rule.sequence ?? 0) + (sequence ?? 0);
+        constraint.setProperties({ sequence: sequenceValue });
+        (parentTargetType ?? targetType).addConstraint(constraint);
+      }
     }
   }
 }


### PR DESCRIPTION
fix:use attribute developer name in rule generation instead of attribute name from source configuration rule

@W-19618832@ - use attribute developer name instead of attribute name from source SCR
