### PR TITLE
@W-19618675: replace "in" operator with "eq" + "or"

### DIFF
--- a/src/shared/bre-rules-generator.ts
+++ b/src/shared/bre-rules-generator.ts
@@ -463,16 +463,25 @@ function convertToCmlExpression(
     case 'DoesNotContain':
       return `!strcontain(${left}, ${doubleQuoted(right as string | undefined)})`;
     case 'In':
-      return `${left} in [${(Array.isArray(right) ? right : [right as string])
-        .map((r) => doubleQuoted(r))
-        .join(', ')}]`;
+      if (right) {
+        return `(${generateInCmlExpression(left, right)})`;
+      }
+      return `${left} == null`;
     case 'NotIn':
-      return `!(${left} in [${(Array.isArray(right) ? right : [right as string])
-        .map((r) => doubleQuoted(r))
-        .join(', ')}])`;
+      if (right) {
+        return `!(${generateInCmlExpression(left, right)})`;
+      }
+      return `${left} != null`;
   }
 
   //  throw new Error(`Operator ${ruleExprOperator} is not supported.`);
+}
+
+function generateInCmlExpression(left: string, right: string | string[]): string {
+  if (typeof right === 'string') {
+    return `${left} == ${doubleQuoted(right)}`;
+  }
+  return `${right.map(r => `${left} == ${doubleQuoted(r)}`).join(' || ')}`;
 }
 
 export class BreRulesGenerator {


### PR DESCRIPTION
Generating of expression like:
Windows_Processor in ["i7-CPU 4.7GHz", "i5-CPU 4.4GHz"] is replaced with generation of expression like this: Windows_Processor =="i7-CPU 4.7GHz" || Windows_Processor =="i5-CPU 4.4GHz"

