### PR TITLE
feat: add insurance dynamic rule migration (surcharge + underwriting)

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -19,6 +19,22 @@
   },
   {
     "alias": [],
+    "command": "cml:convert:surcharge-rules",
+    "flagAliases": [],
+    "flagChars": ["c", "d", "f", "o"],
+    "flags": ["api-version", "cml-api", "flags-dir", "json", "surcharge-file", "target-org", "workspace-dir"],
+    "plugin": "@salesforce/plugin-bre-to-cml"
+  },
+  {
+    "alias": [],
+    "command": "cml:convert:underwriting-rules",
+    "flagAliases": [],
+    "flagChars": ["c", "d", "f", "o"],
+    "flags": ["api-version", "cml-api", "flags-dir", "json", "target-org", "uw-file", "workspace-dir"],
+    "plugin": "@salesforce/plugin-bre-to-cml"
+  },
+  {
+    "alias": [],
     "command": "cml:import:as-expression-set",
     "flagAliases": [],
     "flagChars": ["c", "d", "o", "x"],

--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -21,16 +21,25 @@
     "alias": [],
     "command": "cml:convert:surcharge-rules",
     "flagAliases": [],
-    "flagChars": ["c", "d", "f", "o"],
-    "flags": ["api-version", "cml-api", "flags-dir", "json", "surcharge-file", "target-org", "workspace-dir"],
+    "flagChars": ["c", "d", "f", "o", "s"],
+    "flags": [
+      "api-version",
+      "cml-api",
+      "flags-dir",
+      "json",
+      "surcharge-file",
+      "surcharge-ids",
+      "target-org",
+      "workspace-dir"
+    ],
     "plugin": "@salesforce/plugin-bre-to-cml"
   },
   {
     "alias": [],
     "command": "cml:convert:underwriting-rules",
     "flagAliases": [],
-    "flagChars": ["c", "d", "f", "o"],
-    "flags": ["api-version", "cml-api", "flags-dir", "json", "target-org", "uw-file", "workspace-dir"],
+    "flagChars": ["c", "d", "f", "o", "s"],
+    "flags": ["api-version", "cml-api", "flags-dir", "json", "target-org", "uw-file", "uw-ids", "workspace-dir"],
     "plugin": "@salesforce/plugin-bre-to-cml"
   },
   {

--- a/messages/cml.convert.surcharge-rules.md
+++ b/messages/cml.convert.surcharge-rules.md
@@ -1,0 +1,30 @@
+# summary
+
+Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraints.
+
+# description
+
+Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and generates CML constraints that evaluate surcharge eligibility. Each surcharge rule becomes a named constraint that returns true/false.
+
+The command outputs:
+
+- A .cml file with the constraint model
+- An \_Associations.csv file for ExpressionSetConstraintObj records
+- A \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records
+
+# examples
+
+- <%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --target-org myOrg
+- <%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --surcharge-file data/surcharges.json --workspace-dir data --target-org myOrg
+
+# flags.cml-api.summary
+
+Unique CML API Name to be created.
+
+# flags.workspace-dir.summary
+
+Directory where output files will be written.
+
+# flags.surcharge-file.summary
+
+Optional JSON file with pre-exported ProductSurcharge records. If omitted, records are queried from the org.

--- a/messages/cml.convert.surcharge-rules.md
+++ b/messages/cml.convert.surcharge-rules.md
@@ -28,3 +28,7 @@ Directory where output files will be written.
 # flags.surcharge-file.summary
 
 Optional JSON file with pre-exported ProductSurcharge records. If omitted, records are queried from the org.
+
+# flags.surcharge-ids.summary
+
+Comma-separated list of ProductSurcharge record IDs to convert. If omitted, all records with BRE rules are converted.

--- a/messages/cml.convert.underwriting-rules.md
+++ b/messages/cml.convert.underwriting-rules.md
@@ -28,3 +28,7 @@ Directory where output files will be written.
 # flags.uw-file.summary
 
 Optional JSON file with pre-exported UnderwritingRule records. If omitted, records are queried from the org.
+
+# flags.uw-ids.summary
+
+Comma-separated list of UnderwritingRule record IDs to convert. If omitted, all records with dynamic rules are converted.

--- a/messages/cml.convert.underwriting-rules.md
+++ b/messages/cml.convert.underwriting-rules.md
@@ -1,0 +1,30 @@
+# summary
+
+Converts BRE-based Insurance Underwriting dynamic rules to CML eligibility constraints.
+
+# description
+
+Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false.
+
+The command outputs:
+
+- A .cml file with the constraint model
+- An \_Associations.csv file for ExpressionSetConstraintObj records
+- A \_RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping for updating records
+
+# examples
+
+- <%= config.bin %> <%= command.id %> --cml-api UW_CML --target-org myOrg
+- <%= config.bin %> <%= command.id %> --cml-api UW_CML --uw-file data/underwriting.json --workspace-dir data --target-org myOrg
+
+# flags.cml-api.summary
+
+Unique CML API Name to be created.
+
+# flags.workspace-dir.summary
+
+Directory where output files will be written.
+
+# flags.uw-file.summary
+
+Optional JSON file with pre-exported UnderwritingRule records. If omitted, records are queried from the org.

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -63,6 +63,10 @@ export default class CmlConvertSurchargeRules extends SfCommand<CmlConvertSurcha
       char: 'f',
       exists: true,
     }),
+    'surcharge-ids': Flags.string({
+      summary: messages.getMessage('flags.surcharge-ids.summary'),
+      char: 's',
+    }),
   };
 
   public async run(): Promise<CmlConvertSurchargeRulesResult> {
@@ -100,9 +104,17 @@ export default class CmlConvertSurchargeRules extends SfCommand<CmlConvertSurcha
 
     this.log('Querying ProductSurcharge records from org...');
     const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-    const result = await conn.query<ProductSurchargeRecord>(
-      'SELECT Id, Name, RuleApiName, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null'
-    );
+    const surchargeIds = flags['surcharge-ids'] as string | undefined;
+    let soql =
+      'SELECT Id, Name, RuleApiName, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null';
+    if (surchargeIds) {
+      const idList = surchargeIds
+        .split(',')
+        .map((id) => `'${id.trim()}'`)
+        .join(',');
+      soql += ` AND Id IN (${idList})`;
+    }
+    const result = await conn.query<ProductSurchargeRecord>(soql);
     this.log(`Found ${result.records.length} ProductSurcharge records with BRE rules`);
     return result.records;
   }

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'node:fs/promises';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, Connection } from '@salesforce/core';
+import { CmlModel } from '../../../shared/types/types.js';
+import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import {
+  ParsedRuleDefinition,
+  RuleRecord,
+  RuleKeyEntry,
+  fetchProductCodes,
+  buildCmlModel,
+} from '../../../shared/insurance-rule-converter.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.surcharge-rules');
+
+type ProductSurchargeRecord = RuleRecord & {
+  RuleApiName: string | null;
+  RuleDefinition: string | null;
+};
+
+export type CmlConvertSurchargeRulesResult = {
+  cmlFile: string;
+  associationsFile: string;
+  ruleKeyMapping: RuleKeyEntry[];
+};
+
+export default class CmlConvertSurchargeRules extends SfCommand<CmlConvertSurchargeRulesResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'cml-api': Flags.string({
+      summary: messages.getMessage('flags.cml-api.summary'),
+      char: 'c',
+      required: true,
+    }),
+    'workspace-dir': Flags.directory({
+      summary: messages.getMessage('flags.workspace-dir.summary'),
+      char: 'd',
+      exists: true,
+    }),
+    'surcharge-file': Flags.file({
+      summary: messages.getMessage('flags.surcharge-file.summary'),
+      char: 'f',
+      exists: true,
+    }),
+  };
+
+  public async run(): Promise<CmlConvertSurchargeRulesResult> {
+    const { flags } = await this.parse(CmlConvertSurchargeRules);
+
+    const api = flags['cml-api'];
+    const workspaceDir = flags['workspace-dir'] ?? '.';
+    const targetOrg = flags['target-org'];
+    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+    const records = await this.loadRecords(flags, targetOrg);
+    if (records.length === 0) {
+      this.log('No surcharge rules to convert.');
+      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
+    }
+
+    const ruleDefs = this.parseRuleDefinitions(records);
+    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'SC', 'Surcharge eligibility');
+    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
+
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  private async loadRecords(
+    flags: Record<string, unknown>,
+    targetOrg: { getConnection: (v?: string) => Connection }
+  ): Promise<ProductSurchargeRecord[]> {
+    const surchargeFile = flags['surcharge-file'] as string | undefined;
+    if (surchargeFile) {
+      this.log(`Reading surcharges from file: ${surchargeFile}`);
+      const contents = await fs.readFile(surchargeFile, 'utf8');
+      return JSON.parse(contents) as ProductSurchargeRecord[];
+    }
+
+    this.log('Querying ProductSurcharge records from org...');
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+    const result = await conn.query<ProductSurchargeRecord>(
+      'SELECT Id, Name, RuleApiName, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null'
+    );
+    this.log(`Found ${result.records.length} ProductSurcharge records with BRE rules`);
+    return result.records;
+  }
+
+  private parseRuleDefinitions(
+    records: ProductSurchargeRecord[]
+  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
+    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
+    for (const record of records) {
+      if (!record.RuleDefinition) {
+        this.warn(`Skipping ${record.Name}: no RuleDefinition`);
+        continue;
+      }
+      try {
+        const raw = JSON.parse(record.RuleDefinition) as { ruleApiName?: string; ruleCriteria?: unknown[] };
+        parsed.push({
+          record,
+          ruleDef: {
+            ...raw,
+            name: record.Name,
+            apiName: raw.ruleApiName ?? record.Name,
+            productPath: record.ProductPath,
+          } as ParsedRuleDefinition,
+        });
+      } catch {
+        this.warn(`Failed to parse RuleDefinition for ${record.Name}`);
+      }
+    }
+    this.log(`Parsed ${parsed.length} valid rule definitions`);
+    return parsed;
+  }
+
+  private async resolveProductCodes(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<Map<string, string>> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      return await fetchProductCodes(conn, productIds);
+    } catch (e) {
+      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
+      return new Map<string, string>();
+    }
+  }
+
+  private async writeOutputFiles(
+    cmlModel: CmlModel,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<CmlConvertSurchargeRulesResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
+    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nCML written to: ${cmlPath}`);
+    this.log(`Associations written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`\nConverted ${ruleKeyMapping.length} rules to CML`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the generated .cml file');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+    this.log('  3. Update records with RuleEngineType and RuleKey from mapping file');
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+  }
+}

--- a/src/commands/cml/convert/underwriting-rules.ts
+++ b/src/commands/cml/convert/underwriting-rules.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'node:fs/promises';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Messages, Connection } from '@salesforce/core';
+import { CmlModel } from '../../../shared/types/types.js';
+import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import {
+  ParsedRuleDefinition,
+  RuleRecord,
+  RuleKeyEntry,
+  fetchProductCodes,
+  buildCmlModel,
+} from '../../../shared/insurance-rule-converter.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.underwriting-rules');
+
+type UnderwritingRuleRecord = RuleRecord & {
+  ApiName: string | null;
+  DynamicRuleDefinition: string | null;
+  Status: string | null;
+  Sequence: number | null;
+  RuleKey: string | null;
+};
+
+export type CmlConvertUnderwritingRulesResult = {
+  cmlFile: string;
+  associationsFile: string;
+  ruleKeyMapping: RuleKeyEntry[];
+};
+
+export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnderwritingRulesResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'cml-api': Flags.string({
+      summary: messages.getMessage('flags.cml-api.summary'),
+      char: 'c',
+      required: true,
+    }),
+    'workspace-dir': Flags.directory({
+      summary: messages.getMessage('flags.workspace-dir.summary'),
+      char: 'd',
+      exists: true,
+    }),
+    'uw-file': Flags.file({
+      summary: messages.getMessage('flags.uw-file.summary'),
+      char: 'f',
+      exists: true,
+    }),
+  };
+
+  public async run(): Promise<CmlConvertUnderwritingRulesResult> {
+    const { flags } = await this.parse(CmlConvertUnderwritingRules);
+
+    const api = flags['cml-api'];
+    const workspaceDir = flags['workspace-dir'] ?? '.';
+    const targetOrg = flags['target-org'];
+    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+    const records = await this.loadRecords(flags, targetOrg);
+    if (records.length === 0) {
+      this.log('No underwriting rules to convert.');
+      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
+    }
+
+    const ruleDefs = this.parseRuleDefinitions(records);
+    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'UW', 'Underwriting eligibility');
+    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
+
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  private async loadRecords(
+    flags: Record<string, unknown>,
+    targetOrg: { getConnection: (v?: string) => Connection }
+  ): Promise<UnderwritingRuleRecord[]> {
+    const uwFile = flags['uw-file'] as string | undefined;
+    if (uwFile) {
+      this.log(`Reading underwriting rules from file: ${uwFile}`);
+      const contents = await fs.readFile(uwFile, 'utf8');
+      return JSON.parse(contents) as UnderwritingRuleRecord[];
+    }
+
+    this.log('Querying UnderwritingRule records from org...');
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+    const result = await conn.query<UnderwritingRuleRecord>(
+      'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, Status, Sequence, RuleKey FROM UnderwritingRule'
+    );
+    this.log(`Found ${result.records.length} UnderwritingRule records with BRE rules`);
+    return result.records;
+  }
+
+  private parseRuleDefinitions(
+    records: UnderwritingRuleRecord[]
+  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
+    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
+    for (const record of records) {
+      if (!record.DynamicRuleDefinition) {
+        this.warn(`Skipping ${record.Name}: no DynamicRuleDefinition`);
+        continue;
+      }
+      try {
+        const raw = JSON.parse(record.DynamicRuleDefinition) as {
+          apiName?: string;
+          name?: string;
+          status?: string;
+          description?: string;
+          productPath?: string;
+          ruleCriteria?: unknown[];
+        };
+        parsed.push({
+          record,
+          ruleDef: {
+            ...raw,
+            name: raw.name ?? record.Name,
+            apiName: raw.apiName ?? record.ApiName ?? record.Name,
+            productPath: raw.productPath ?? record.ProductPath,
+          } as ParsedRuleDefinition,
+        });
+      } catch {
+        this.warn(`Failed to parse DynamicRuleDefinition for ${record.Name}`);
+      }
+    }
+    this.log(`Parsed ${parsed.length} valid rule definitions`);
+    return parsed;
+  }
+
+  private async resolveProductCodes(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<Map<string, string>> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      return await fetchProductCodes(conn, productIds);
+    } catch (e) {
+      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
+      return new Map<string, string>();
+    }
+  }
+
+  private async writeOutputFiles(
+    cmlModel: CmlModel,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<CmlConvertUnderwritingRulesResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
+    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nCML written to: ${cmlPath}`);
+    this.log(`Associations written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`\nConverted ${ruleKeyMapping.length} underwriting rules to CML`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the generated .cml file');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+    this.log('  3. Update UnderwritingRule records with RuleKey from mapping file');
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+  }
+}

--- a/src/commands/cml/convert/underwriting-rules.ts
+++ b/src/commands/cml/convert/underwriting-rules.ts
@@ -66,6 +66,10 @@ export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnd
       char: 'f',
       exists: true,
     }),
+    'uw-ids': Flags.string({
+      summary: messages.getMessage('flags.uw-ids.summary'),
+      char: 's',
+    }),
   };
 
   public async run(): Promise<CmlConvertUnderwritingRulesResult> {
@@ -103,9 +107,17 @@ export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnd
 
     this.log('Querying UnderwritingRule records from org...');
     const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-    const result = await conn.query<UnderwritingRuleRecord>(
-      'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, Status, Sequence, RuleKey FROM UnderwritingRule'
-    );
+    const uwIds = flags['uw-ids'] as string | undefined;
+    let soql =
+      'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, Status, Sequence, RuleKey FROM UnderwritingRule WHERE DynamicRuleDefinition != null';
+    if (uwIds) {
+      const idList = uwIds
+        .split(',')
+        .map((id) => `'${id.trim()}'`)
+        .join(',');
+      soql += ` AND Id IN (${idList})`;
+    }
+    const result = await conn.query<UnderwritingRuleRecord>(soql);
     this.log(`Found ${result.records.length} UnderwritingRule records with BRE rules`);
     return result.records;
   }

--- a/src/shared/insurance-rule-converter.ts
+++ b/src/shared/insurance-rule-converter.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Connection } from '@salesforce/core';
+import {
+  BASE_LINE_ITEM_TYPE_NAME,
+  CmlAttribute,
+  CmlConstraint,
+  CmlModel,
+  CmlType,
+  Association,
+} from './types/types.js';
+import { CML_DATA_TYPES, CONSTRAINT_TYPES, ASSOCIATION_TYPES } from './constants/constants.js';
+
+// Shared types for insurance dynamic rule criteria (same for surcharge + underwriting)
+export type RuleCondition = {
+  contextTagName?: string;
+  operator: string;
+  conditionIndex?: number;
+  attributeName?: string;
+  attributePicklistValueId?: string;
+  attributeId?: string;
+  dataType?: string;
+  type?: string;
+  values?: string[];
+};
+
+export type RuleCriteria = {
+  rootObjectId: string;
+  criteriaIndex?: number;
+  sourceContextTagName?: string;
+  sourceOperator?: string;
+  sourceDataType?: string;
+  sourceValues?: string[];
+  conditions?: RuleCondition[];
+};
+
+export type ParsedRuleDefinition = {
+  name: string;
+  apiName: string;
+  productPath: string;
+  status?: string;
+  description?: string;
+  ruleCriteria?: RuleCriteria[];
+};
+
+export type RuleRecord = {
+  Id: string;
+  Name: string;
+  ProductPath: string;
+};
+
+export type RuleKeyEntry = {
+  recordId: string;
+  name: string;
+  ruleKey: string;
+};
+
+function operatorToCml(op: string): string {
+  const operators: Record<string, string> = {
+    Equals: '==',
+    NotEquals: '!=',
+    LessThan: '<',
+    LessThanOrEquals: '<=',
+    GreaterThan: '>',
+    GreaterThanOrEquals: '>=',
+    Contains: '.contains',
+    In: '==',
+  };
+  return operators[op] ?? '==';
+}
+
+function dataTypeToCml(dataType?: string): string {
+  const types: Record<string, string> = {
+    Number: CML_DATA_TYPES.INTEGER,
+    Integer: CML_DATA_TYPES.INTEGER,
+    Percent: CML_DATA_TYPES.DECIMAL,
+    Currency: CML_DATA_TYPES.DECIMAL,
+    Boolean: CML_DATA_TYPES.BOOLEAN,
+    Date: CML_DATA_TYPES.DATE,
+    DateTime: CML_DATA_TYPES.DATE,
+  };
+  return (dataType && types[dataType]) ?? CML_DATA_TYPES.STRING;
+}
+
+export function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+export function generateRuleKey(prefix: string, productCode: string, apiName: string): string {
+  return `${prefix}__${sanitizeName(productCode)}__${sanitizeName(apiName)}`;
+}
+
+function buildConditionExpression(condition: RuleCondition): string | null {
+  if (!condition.values || condition.values.length === 0) return null;
+
+  const attrName = sanitizeName(condition.attributeName ?? condition.contextTagName ?? 'unknown');
+  const op = operatorToCml(condition.operator);
+  const value = condition.values[0];
+  const cmlDataType = dataTypeToCml(condition.dataType);
+  const isNumeric = cmlDataType === CML_DATA_TYPES.INTEGER || cmlDataType === CML_DATA_TYPES.DECIMAL;
+  const quotedValue = isNumeric ? value : `"${value}"`;
+
+  return `${attrName} ${op} ${quotedValue}`;
+}
+
+function buildCriteriaExpression(criteria: RuleCriteria): string | null {
+  const parts: string[] = [];
+
+  if (criteria.sourceContextTagName === 'Product' && criteria.sourceValues && criteria.sourceValues.length > 0) {
+    const productIds = criteria.sourceValues.map((v) => `"${v}"`).join(', ');
+    parts.push(criteria.sourceValues.length === 1 ? `product.id == ${productIds}` : `product.id in [${productIds}]`);
+  }
+
+  if (criteria.conditions) {
+    for (const condition of criteria.conditions) {
+      const expr = buildConditionExpression(condition);
+      if (expr) parts.push(expr);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' && ') : null;
+}
+
+export function buildConstraintDeclaration(ruleDef: { ruleCriteria?: RuleCriteria[] }): string {
+  if (!ruleDef.ruleCriteria || ruleDef.ruleCriteria.length === 0) {
+    return 'true';
+  }
+
+  const expressions = ruleDef.ruleCriteria.map(buildCriteriaExpression).filter((e): e is string => e !== null);
+
+  if (expressions.length === 0) return 'true';
+  if (expressions.length === 1) return expressions[0];
+  return expressions.map((e) => `(${e})`).join(' || ');
+}
+
+export function collectAttributes(ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>): Set<string> {
+  const attrs = new Set<string>();
+  for (const { ruleDef } of ruleDefs) {
+    for (const criteria of ruleDef.ruleCriteria ?? []) {
+      for (const cond of criteria.conditions ?? []) {
+        const name = cond.attributeName ?? cond.contextTagName;
+        if (name) attrs.add(name);
+      }
+    }
+  }
+  return attrs;
+}
+
+export async function fetchProductCodes(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
+  const idToCode = new Map<string, string>();
+  if (productIds.size === 0) return idToCode;
+
+  const idList = Array.from(productIds)
+    .map((id) => `'${id}'`)
+    .join(',');
+  const result = await conn.query<{ Id: string; ProductCode: string }>(
+    `SELECT Id, ProductCode FROM Product2 WHERE Id IN (${idList})`
+  );
+  for (const p of result.records) {
+    idToCode.set(p.Id, p.ProductCode ?? p.Id);
+  }
+  return idToCode;
+}
+
+export function buildCmlModel(
+  ruleDefs: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>,
+  productIdToCode: Map<string, string>,
+  keyPrefix: string,
+  constraintLabel: string
+): { cmlModel: CmlModel; ruleKeyMapping: RuleKeyEntry[] } {
+  const cmlModel = new CmlModel();
+  const lineItemType = new CmlType(BASE_LINE_ITEM_TYPE_NAME, undefined, undefined);
+
+  const commonAttrs = collectAttributes(ruleDefs);
+  lineItemType.addAttribute(new CmlAttribute(null, 'product_id', CML_DATA_TYPES.STRING));
+  for (const attrName of commonAttrs) {
+    lineItemType.addAttribute(new CmlAttribute(null, sanitizeName(attrName), CML_DATA_TYPES.STRING));
+  }
+  cmlModel.addType(lineItemType);
+
+  const ruleKeyMapping: RuleKeyEntry[] = [];
+  for (const { record, ruleDef } of ruleDefs) {
+    const rootProductId = record.ProductPath.split('/')[0];
+    const productCode = productIdToCode.get(rootProductId) ?? rootProductId;
+    const apiName = ruleDef.apiName ?? record.Name;
+    const ruleKey = generateRuleKey(keyPrefix, productCode, apiName);
+
+    const constraint = new CmlConstraint(
+      CONSTRAINT_TYPES.CONSTRAINT,
+      buildConstraintDeclaration(ruleDef),
+      `"${constraintLabel}: ${record.Name}"`
+    );
+    constraint.name = sanitizeName(apiName);
+    lineItemType.addConstraint(constraint);
+
+    cmlModel.addAssociation(
+      new Association(null, BASE_LINE_ITEM_TYPE_NAME, ASSOCIATION_TYPES.TYPE, rootProductId, 'Product2', productCode)
+    );
+
+    ruleKeyMapping.push({ recordId: record.Id, name: record.Name, ruleKey });
+  }
+
+  return { cmlModel, ruleKeyMapping };
+}

--- a/src/shared/insurance-rule-converter.ts
+++ b/src/shared/insurance-rule-converter.ts
@@ -258,7 +258,7 @@ export function buildCmlModel(
 
   const ruleKeyMapping: RuleKeyEntry[] = [];
   for (const { record, ruleDef } of ruleDefs) {
-    const rootProductId = ruleDef.ruleCriteria?.[0]?.rootObjectId ?? record.ProductPath.split('/')[0];
+    const rootProductId = record.ProductPath.split('/')[0];
     const productCode = productIdToCode.get(rootProductId) ?? rootProductId;
     const apiName = ruleDef.apiName ?? record.Name;
     const ruleKey = generateRuleKey(keyPrefix, productCode, apiName);
@@ -268,7 +268,7 @@ export function buildCmlModel(
       buildConstraintDeclaration(ruleDef),
       `"${constraintLabel}: ${record.Name}"`
     );
-    constraint.name = sanitizeName(apiName);
+    constraint.name = ruleKey;
     lineItemType.addConstraint(constraint);
 
     cmlModel.addAssociation(

--- a/src/shared/insurance-rule-converter.ts
+++ b/src/shared/insurance-rule-converter.ts
@@ -24,7 +24,6 @@ import {
 } from './types/types.js';
 import { CML_DATA_TYPES, CONSTRAINT_TYPES, ASSOCIATION_TYPES } from './constants/constants.js';
 
-// Shared types for insurance dynamic rule criteria (same for surcharge + underwriting)
 export type RuleCondition = {
   contextTagName?: string;
   operator: string;
@@ -53,6 +52,7 @@ export type ParsedRuleDefinition = {
   productPath: string;
   status?: string;
   description?: string;
+  criteriaExpressionType?: string;
   ruleCriteria?: RuleCriteria[];
 };
 
@@ -68,18 +68,32 @@ export type RuleKeyEntry = {
   ruleKey: string;
 };
 
-function operatorToCml(op: string): string {
-  const operators: Record<string, string> = {
-    Equals: '==',
-    NotEquals: '!=',
-    LessThan: '<',
-    LessThanOrEquals: '<=',
-    GreaterThan: '>',
-    GreaterThanOrEquals: '>=',
-    Contains: '.contains',
-    In: '==',
-  };
-  return operators[op] ?? '==';
+function doubleQuoted(value: string | undefined): string {
+  return `"${value ?? ''}"`;
+}
+
+function operatorToCml(op: string): string | null {
+  switch (op) {
+    case 'Equals':
+      return '==';
+    case 'NotEquals':
+      return '!=';
+    case 'LessThan':
+      return '<';
+    case 'LessThanOrEquals':
+      return '<=';
+    case 'GreaterThan':
+      return '>';
+    case 'GreaterThanOrEquals':
+      return '>=';
+    case 'Contains':
+    case 'DoesNotContain':
+    case 'In':
+    case 'NotIn':
+      return null; // handled separately
+    default:
+      return '==';
+  }
 }
 
 function dataTypeToCml(dataType?: string): string {
@@ -91,6 +105,7 @@ function dataTypeToCml(dataType?: string): string {
     Boolean: CML_DATA_TYPES.BOOLEAN,
     Date: CML_DATA_TYPES.DATE,
     DateTime: CML_DATA_TYPES.DATE,
+    Picklist: CML_DATA_TYPES.STRING,
   };
   return (dataType && types[dataType]) ?? CML_DATA_TYPES.STRING;
 }
@@ -103,25 +118,62 @@ export function generateRuleKey(prefix: string, productCode: string, apiName: st
   return `${prefix}__${sanitizeName(productCode)}__${sanitizeName(apiName)}`;
 }
 
+function formatValue(value: string, cmlDataType: string): string {
+  const isNumeric = cmlDataType === CML_DATA_TYPES.INTEGER || cmlDataType === CML_DATA_TYPES.DECIMAL;
+  return isNumeric ? value : doubleQuoted(value);
+}
+
+function generateInExpression(left: string, values: string[], cmlDataType: string): string {
+  if (values.length === 1) {
+    return `${left} == ${formatValue(values[0], cmlDataType)}`;
+  }
+  return values.map((v) => `${left} == ${formatValue(v, cmlDataType)}`).join(' || ');
+}
+
+function resolveConditionName(condition: RuleCondition): string {
+  if (condition.type === 'Attribute' && condition.attributeName) {
+    return condition.attributeName;
+  }
+  if (condition.type === 'Tag' && condition.contextTagName) {
+    return condition.contextTagName;
+  }
+  return condition.attributeName ?? condition.contextTagName ?? 'unknown';
+}
+
 function buildConditionExpression(condition: RuleCondition): string | null {
   if (!condition.values || condition.values.length === 0) return null;
 
-  const attrName = sanitizeName(condition.attributeName ?? condition.contextTagName ?? 'unknown');
-  const op = operatorToCml(condition.operator);
-  const value = condition.values[0];
+  const rawName = resolveConditionName(condition);
+  const attrName = sanitizeName(rawName);
   const cmlDataType = dataTypeToCml(condition.dataType);
-  const isNumeric = cmlDataType === CML_DATA_TYPES.INTEGER || cmlDataType === CML_DATA_TYPES.DECIMAL;
-  const quotedValue = isNumeric ? value : `"${value}"`;
+  const values = condition.values;
 
-  return `${attrName} ${op} ${quotedValue}`;
+  switch (condition.operator) {
+    case 'Contains':
+      return `strcontain(${attrName}, ${doubleQuoted(values[0])})`;
+    case 'DoesNotContain':
+      return `!strcontain(${attrName}, ${doubleQuoted(values[0])})`;
+    case 'In':
+      return `(${generateInExpression(attrName, values, cmlDataType)})`;
+    case 'NotIn':
+      return `!(${generateInExpression(attrName, values, cmlDataType)})`;
+    default: {
+      const op = operatorToCml(condition.operator);
+      if (!op) return null;
+      return `${attrName} ${op} ${formatValue(values[0], cmlDataType)}`;
+    }
+  }
 }
 
 function buildCriteriaExpression(criteria: RuleCriteria): string | null {
   const parts: string[] = [];
 
   if (criteria.sourceContextTagName === 'Product' && criteria.sourceValues && criteria.sourceValues.length > 0) {
-    const productIds = criteria.sourceValues.map((v) => `"${v}"`).join(', ');
-    parts.push(criteria.sourceValues.length === 1 ? `product.id == ${productIds}` : `product.id in [${productIds}]`);
+    if (criteria.sourceValues.length === 1) {
+      parts.push(`product.id == ${doubleQuoted(criteria.sourceValues[0])}`);
+    } else {
+      parts.push(`(${generateInExpression('product.id', criteria.sourceValues, CML_DATA_TYPES.STRING)})`);
+    }
   }
 
   if (criteria.conditions) {
@@ -134,7 +186,10 @@ function buildCriteriaExpression(criteria: RuleCriteria): string | null {
   return parts.length > 0 ? parts.join(' && ') : null;
 }
 
-export function buildConstraintDeclaration(ruleDef: { ruleCriteria?: RuleCriteria[] }): string {
+export function buildConstraintDeclaration(ruleDef: {
+  criteriaExpressionType?: string;
+  ruleCriteria?: RuleCriteria[];
+}): string {
   if (!ruleDef.ruleCriteria || ruleDef.ruleCriteria.length === 0) {
     return 'true';
   }
@@ -143,16 +198,26 @@ export function buildConstraintDeclaration(ruleDef: { ruleCriteria?: RuleCriteri
 
   if (expressions.length === 0) return 'true';
   if (expressions.length === 1) return expressions[0];
-  return expressions.map((e) => `(${e})`).join(' || ');
+
+  const joiner = ruleDef.criteriaExpressionType?.toUpperCase() === 'ALL' ? ' && ' : ' || ';
+  return expressions.map((e) => `(${e})`).join(joiner);
 }
 
-export function collectAttributes(ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>): Set<string> {
-  const attrs = new Set<string>();
+export function collectAttributes(
+  ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>
+): Map<string, { name: string; attributeId: string | null; cmlDataType: string }> {
+  const attrs = new Map<string, { name: string; attributeId: string | null; cmlDataType: string }>();
   for (const { ruleDef } of ruleDefs) {
     for (const criteria of ruleDef.ruleCriteria ?? []) {
       for (const cond of criteria.conditions ?? []) {
-        const name = cond.attributeName ?? cond.contextTagName;
-        if (name) attrs.add(name);
+        const name = resolveConditionName(cond);
+        if (name && !attrs.has(name)) {
+          attrs.set(name, {
+            name,
+            attributeId: cond.attributeId ?? null,
+            cmlDataType: dataTypeToCml(cond.dataType),
+          });
+        }
       }
     }
   }
@@ -184,16 +249,16 @@ export function buildCmlModel(
   const cmlModel = new CmlModel();
   const lineItemType = new CmlType(BASE_LINE_ITEM_TYPE_NAME, undefined, undefined);
 
-  const commonAttrs = collectAttributes(ruleDefs);
+  const attrMap = collectAttributes(ruleDefs);
   lineItemType.addAttribute(new CmlAttribute(null, 'product_id', CML_DATA_TYPES.STRING));
-  for (const attrName of commonAttrs) {
-    lineItemType.addAttribute(new CmlAttribute(null, sanitizeName(attrName), CML_DATA_TYPES.STRING));
+  for (const [, attr] of attrMap) {
+    lineItemType.addAttribute(new CmlAttribute(attr.attributeId, sanitizeName(attr.name), attr.cmlDataType));
   }
   cmlModel.addType(lineItemType);
 
   const ruleKeyMapping: RuleKeyEntry[] = [];
   for (const { record, ruleDef } of ruleDefs) {
-    const rootProductId = record.ProductPath.split('/')[0];
+    const rootProductId = ruleDef.ruleCriteria?.[0]?.rootObjectId ?? record.ProductPath.split('/')[0];
     const productCode = productIdToCode.get(rootProductId) ?? rootProductId;
     const apiName = ruleDef.apiName ?? record.Name;
     const ruleKey = generateRuleKey(keyPrefix, productCode, apiName);


### PR DESCRIPTION
## Summary

Adds two new commands to convert Insurance BRE dynamic rules to CML eligibility constraints:

- **`sf cml convert surcharge-rules`** — reads `ProductSurcharge.RuleDefinition` from org or JSON file
- **`sf cml convert underwriting-rules`** — reads `UnderwritingRule.DynamicRuleDefinition` from org or JSON file

Both convert `ruleCriteria` conditions into CML boolean constraints (eligibility-only, no actions), outputting `.cml`, `_Associations.csv`, and `_RuleKeyMapping.json` files. Import uses the existing `sf cml import as-expression-set` command.

### Files added
- `src/shared/insurance-rule-converter.ts` — shared criteria→constraint conversion, product code resolution
- `src/commands/cml/convert/surcharge-rules.ts` — surcharge command
- `src/commands/cml/convert/underwriting-rules.ts` — underwriting command
- `messages/cml.convert.surcharge-rules.md` — help text
- `messages/cml.convert.underwriting-rules.md` — help text
- `command-snapshot.json` — updated with new commands

### Context
Insurance dynamic rules (surcharge/underwriting) use the same `ruleCriteria` schema as Configurator rules but are stored on different entities (`ProductSurcharge.RuleDefinition`, `UnderwritingRule.DynamicRuleDefinition`) and are eligibility-only (pass/fail, no actions like AutoAdd/SetAttribute). The Insurance-Chewbacca team is adding CML support for surcharges in Core (W-21817142).

### Example output
```
constraint Auto_WA_Tax = (product.id == "01tSB000004V4KLYA0" && Colour == "Red",
    "Surcharge eligibility: Auto_WA_Tax");

constraint DriverAccidentsLT2AndAutoConditionGood = (
    (product.id == "01tSB000004V4KpYAK" && Driver_Accident_Points < 2) ||
    (product.id == "01tSB000004V4KLYA0" && Auto_Value > 25000),
    "Underwriting eligibility: DriverAccidentsLT2AndAutoConditionGood");
```

## Test plan
- [x] Tested `sf cml convert surcharge-rules` against live org (6 rules converted)
- [x] Tested `sf cml convert underwriting-rules` against live org (9 rules converted)
- [x] Handles Attribute-type and Tag-type conditions (e.g., UserProfile)
- [x] Resolves product codes from org when available, falls back to product IDs
- [x] `yarn build` passes (lint + compile + snapshot)
- [ ] Import via `sf cml import as-expression-set` on a 264+ org with RuleEngineType field