### PR TITLE
W-22787786: feat(insurance): add surcharge and underwriting BRE-to-CML converters

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -19,6 +19,40 @@
   },
   {
     "alias": [],
+    "command": "cml:convert:surcharge-rules",
+    "flagAliases": [],
+    "flagChars": ["c", "d", "f", "o"],
+    "flags": [
+      "api-version",
+      "cml-api",
+      "flags-dir",
+      "json",
+      "surcharge-file",
+      "target-org",
+      "update-records",
+      "workspace-dir"
+    ],
+    "plugin": "@salesforce/plugin-bre-to-cml"
+  },
+  {
+    "alias": [],
+    "command": "cml:convert:underwriting-rules",
+    "flagAliases": [],
+    "flagChars": ["c", "d", "f", "o"],
+    "flags": [
+      "api-version",
+      "cml-api",
+      "flags-dir",
+      "json",
+      "target-org",
+      "update-records",
+      "uw-file",
+      "workspace-dir"
+    ],
+    "plugin": "@salesforce/plugin-bre-to-cml"
+  },
+  {
+    "alias": [],
     "command": "cml:import:as-expression-set",
     "flagAliases": [],
     "flagChars": ["c", "d", "o", "x"],

--- a/messages/cml.convert.insurance-shared.md
+++ b/messages/cml.convert.insurance-shared.md
@@ -1,0 +1,11 @@
+# flags.cml-api.summary
+
+CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.
+
+# flags.workspace-dir.summary
+
+Directory where output files will be written.
+
+# flags.update-records.summary
+
+Update source records in the org with RuleEngineType=ConstraintEngine.

--- a/messages/cml.convert.surcharge-rules.md
+++ b/messages/cml.convert.surcharge-rules.md
@@ -1,0 +1,17 @@
+# summary
+
+Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraints.
+
+# description
+
+Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and generates CML constraints that evaluate surcharge eligibility. Each surcharge rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an \_Associations.csv file for ExpressionSetConstraintObj records, and a \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.
+
+# examples
+
+- <%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --target-org myOrg
+
+- <%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --surcharge-file path/to/surcharges.json --workspace-dir data --target-org myOrg
+
+# flags.surcharge-file.summary
+
+Optional JSON file with pre-exported ProductSurcharge records. If omitted, records are queried from the org.

--- a/messages/cml.convert.underwriting-rules.md
+++ b/messages/cml.convert.underwriting-rules.md
@@ -1,0 +1,17 @@
+# summary
+
+Converts BRE-based Insurance Underwriting dynamic rules to CML eligibility constraints.
+
+# description
+
+Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an \_Associations.csv file for ExpressionSetConstraintObj records, and a \_RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping for updating records.
+
+# examples
+
+- <%= config.bin %> <%= command.id %> --cml-api UW_CML --target-org myOrg
+
+- <%= config.bin %> <%= command.id %> --cml-api UW_CML --uw-file data/underwriting.json --workspace-dir data --target-org myOrg
+
+# flags.uw-file.summary
+
+Optional JSON file with pre-exported UnderwritingRule records. If omitted, records are queried from the org.

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -13,225 +13,97 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'node:fs/promises';
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Connection } from '@salesforce/core';
-import { CmlModel } from '../../../shared/types/types.js';
-import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import { Flags } from '@salesforce/sf-plugins-core';
+import { Connection, Messages } from '@salesforce/core';
 import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
-import { buildCmlModel } from '../../../shared/insurance/insurance-rule-generator.js';
-import { discoverCmlApiByProducts, fetchProductCodes } from '../../../shared/insurance/insurance-org.js';
+import {
+  InsuranceRuleConvertCommand,
+  InsuranceRuleConvertResult,
+} from '../../../shared/insurance/insurance-rule-convert-command.js';
+import { decodeHtmlEntities } from '../../../shared/insurance/insurance-rule-generator.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.surcharge-rules');
 
 type ProductSurchargeRecord = RuleRecord & {
-  RuleApiName: string | null;
   RuleDefinition: string | null;
 };
 
-export type CmlConvertSurchargeRulesResult = {
-  cmlFile: string;
-  associationsFile: string;
-  ruleKeyMapping: RuleKeyEntry[];
-};
+export type CmlConvertSurchargeRulesResult = InsuranceRuleConvertResult;
 
-export default class CmlConvertSurchargeRules extends SfCommand<CmlConvertSurchargeRulesResult> {
-  public static readonly summary = 'Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraints.';
-  public static readonly description =
-    'Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and generates CML constraints that evaluate surcharge eligibility. Each surcharge rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an _Associations.csv file for ExpressionSetConstraintObj records, and a _RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.';
-  public static readonly examples = [
-    '<%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --target-org myOrg',
-    '<%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --surcharge-file path/to/surcharges.json --workspace-dir data --target-org myOrg',
-  ];
+// eslint-disable-next-line sf-plugin/only-extend-SfCommand
+export default class CmlConvertSurchargeRules extends InsuranceRuleConvertCommand<ProductSurchargeRecord> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
 
   public static readonly flags = {
-    'target-org': Flags.requiredOrg(),
-    'api-version': Flags.orgApiVersion(),
-    'cml-api': Flags.string({
-      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
-      char: 'c',
-    }),
-    'workspace-dir': Flags.directory({
-      summary: 'Directory where output files will be written.',
-      char: 'd',
-      exists: true,
-    }),
+    ...InsuranceRuleConvertCommand.flags,
     'surcharge-file': Flags.file({
-      summary:
-        'Optional JSON file with pre-exported ProductSurcharge records. If omitted, records are queried from the org.',
+      summary: messages.getMessage('flags.surcharge-file.summary'),
       char: 'f',
       exists: true,
     }),
-    'update-records': Flags.boolean({
-      summary: 'Update ProductSurcharge records in the org with RuleEngineType=ConstraintEngine.',
-      default: false,
-    }),
   };
+
+  protected readonly recordLabel = 'ProductSurcharge';
+  protected readonly keyPrefix = 'SC';
+  protected readonly constraintLabel = 'Surcharge eligibility';
+  protected readonly apiNamePrefix = 'SC_';
+  protected readonly soql =
+    'SELECT Id, Name, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null';
 
   public async run(): Promise<CmlConvertSurchargeRulesResult> {
     const { flags } = await this.parse(CmlConvertSurchargeRules);
-
-    const workspaceDir = flags['workspace-dir'] ?? '.';
-    const targetOrg = flags['target-org'];
-
-    const records = await this.loadRecords(flags, targetOrg);
-    if (records.length === 0) {
-      this.log('No surcharge rules to convert.');
-      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
-    }
-
-    const ruleDefs = this.parseRuleDefinitions(records);
-    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
-
-    const api = flags['cml-api'] ?? (await this.discoverCmlApi(ruleDefs, productIdToCode, targetOrg, flags));
-    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'SC', 'Surcharge eligibility');
-    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
-
-    if (flags['update-records']) {
-      await this.updateOrgRecords(targetOrg, flags, ruleKeyMapping);
-    }
-
-    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+    return this.runConvert({
+      targetOrg: flags['target-org'],
+      apiVersion: flags['api-version'],
+      cmlApi: flags['cml-api'],
+      workspaceDir: flags['workspace-dir'],
+      inputFile: flags['surcharge-file'],
+      updateRecords: flags['update-records'],
+    });
   }
 
-  private async loadRecords(
-    flags: Record<string, unknown>,
-    targetOrg: { getConnection: (v?: string) => Connection }
-  ): Promise<ProductSurchargeRecord[]> {
-    const surchargeFile = flags['surcharge-file'] as string | undefined;
-    if (surchargeFile) {
-      this.log(`Reading surcharges from file: ${surchargeFile}`);
-      const contents = await fs.readFile(surchargeFile, 'utf8');
-      return JSON.parse(contents) as ProductSurchargeRecord[];
-    }
-
-    this.log('Querying ProductSurcharge records from org...');
-    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-    const result = await conn.query<ProductSurchargeRecord>(
-      'SELECT Id, Name, RuleApiName, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null'
-    );
-    this.log(`Found ${result.records.length} ProductSurcharge records with BRE rules`);
-    return result.records;
-  }
-
-  private parseRuleDefinitions(
-    records: ProductSurchargeRecord[]
-  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
-    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
-    for (const record of records) {
-      if (!record.RuleDefinition) {
-        this.warn(`Skipping ${record.Name}: no RuleDefinition`);
-        continue;
-      }
-      try {
-        const raw = JSON.parse(record.RuleDefinition) as { ruleApiName?: string; ruleCriteria?: unknown[] };
-        parsed.push({
-          record,
-          ruleDef: {
-            ...raw,
-            name: record.Name,
-            apiName: raw.ruleApiName ?? record.Name,
-            productPath: record.ProductPath,
-          } as ParsedRuleDefinition,
-        });
-      } catch {
-        this.warn(`Failed to parse RuleDefinition for ${record.Name}`);
-      }
-    }
-    this.log(`Parsed ${parsed.length} valid rule definitions`);
-    return parsed;
-  }
-
-  private async discoverCmlApi(
-    ruleDefs: Array<{ record: RuleRecord }>,
-    productIdToCode: Map<string, string>,
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>
-  ): Promise<string> {
-    const productIds = new Set<string>();
-    for (const { record } of ruleDefs) {
-      productIds.add(record.ProductPath.split('/')[0]);
+  protected parseRecord(record: ProductSurchargeRecord): ParsedRuleDefinition | null {
+    if (!record.RuleDefinition) {
+      this.warn(`Skipping ${record.Name}: no RuleDefinition`);
+      return null;
     }
     try {
-      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-      const discovered = await discoverCmlApiByProducts(conn, productIds);
-      if (discovered) {
-        this.log(`Auto-discovered existing CML API: ${discovered}`);
-        return discovered;
-      }
-    } catch (e) {
-      this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
-    }
-
-    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
-    const generated = `SC_${codes.join('_')}`;
-    this.log(`No existing CML found. Generated new CML API name: ${generated}`);
-    return generated;
-  }
-
-  private async resolveProductCodes(
-    ruleDefs: Array<{ record: RuleRecord }>,
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>
-  ): Promise<Map<string, string>> {
-    const productIds = new Set<string>();
-    for (const { record } of ruleDefs) {
-      productIds.add(record.ProductPath.split('/')[0]);
-    }
-    try {
-      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-      return await fetchProductCodes(conn, productIds);
-    } catch (e) {
-      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
-      return new Map<string, string>();
+      const raw = JSON.parse(decodeHtmlEntities(record.RuleDefinition)) as {
+        ruleApiName?: string;
+        ruleCriteria?: unknown[];
+      };
+      return {
+        ...raw,
+        name: record.Name,
+        apiName: raw.ruleApiName ?? record.Name,
+        productPath: record.ProductPath,
+      } as ParsedRuleDefinition;
+    } catch {
+      this.warn(`Failed to parse RuleDefinition for ${record.Name}`);
+      return null;
     }
   }
 
-  private async updateOrgRecords(
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>,
-    ruleKeyMapping: RuleKeyEntry[]
+  protected async updateOrgRecords(
+    _records: ProductSurchargeRecord[],
+    ruleKeyMapping: RuleKeyEntry[],
+    conn: Connection
   ): Promise<void> {
-    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-    this.log('\nUpdating ProductSurcharge records with RuleEngineType and RuleKey...');
+    this.log('\nUpdating ProductSurcharge records with RuleEngineType=ConstraintEngine...');
     const updates = ruleKeyMapping.map((m) => ({
       Id: m.recordId,
       RuleEngineType: 'ConstraintEngine',
     }));
     const results = await conn.sobject('ProductSurcharge').update(updates);
-    const successes = (Array.isArray(results) ? results : [results]).filter((r) => r.success);
-    const failures = (Array.isArray(results) ? results : [results]).filter((r) => !r.success);
+    const list = Array.isArray(results) ? results : [results];
+    const successes = list.filter((r) => r.success);
+    const failures = list.filter((r) => !r.success);
     this.log(`  Updated ${successes.length} records successfully`);
     for (const f of failures) {
       this.warn(`  Failed to update ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
     }
-  }
-
-  private async writeOutputFiles(
-    cmlModel: CmlModel,
-    ruleKeyMapping: RuleKeyEntry[],
-    safeApi: string,
-    workspaceDir: string,
-    api: string
-  ): Promise<CmlConvertSurchargeRulesResult> {
-    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
-    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
-    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
-
-    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
-    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
-    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
-
-    this.log(`\nCML written to: ${cmlPath}`);
-    this.log(`Associations written to: ${associationsPath}`);
-    this.log(`Rule key mapping written to: ${mappingPath}`);
-    this.log(`\nConverted ${ruleKeyMapping.length} rules to CML`);
-    this.log('\nNext steps:');
-    this.log('  1. Review the generated .cml file');
-    this.log(
-      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
-    );
-    this.log('  3. Update records with RuleEngineType and RuleKey from mapping file');
-
-    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
   }
 }

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'node:fs/promises';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Connection } from '@salesforce/core';
+import { CmlModel } from '../../../shared/types/types.js';
+import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
+import { buildCmlModel } from '../../../shared/insurance/insurance-rule-generator.js';
+import { discoverCmlApiByProducts, fetchProductCodes } from '../../../shared/insurance/insurance-org.js';
+
+type ProductSurchargeRecord = RuleRecord & {
+  RuleApiName: string | null;
+  RuleDefinition: string | null;
+};
+
+export type CmlConvertSurchargeRulesResult = {
+  cmlFile: string;
+  associationsFile: string;
+  ruleKeyMapping: RuleKeyEntry[];
+};
+
+export default class CmlConvertSurchargeRules extends SfCommand<CmlConvertSurchargeRulesResult> {
+  public static readonly summary = 'Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraints.';
+  public static readonly description =
+    'Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and generates CML constraints that evaluate surcharge eligibility. Each surcharge rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an _Associations.csv file for ExpressionSetConstraintObj records, and a _RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.';
+  public static readonly examples = [
+    '<%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --target-org myOrg',
+    '<%= config.bin %> <%= command.id %> --cml-api SURCHARGE_CML --surcharge-file path/to/surcharges.json --workspace-dir data --target-org myOrg',
+  ];
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'cml-api': Flags.string({
+      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
+      char: 'c',
+    }),
+    'workspace-dir': Flags.directory({
+      summary: 'Directory where output files will be written.',
+      char: 'd',
+      exists: true,
+    }),
+    'surcharge-file': Flags.file({
+      summary:
+        'Optional JSON file with pre-exported ProductSurcharge records. If omitted, records are queried from the org.',
+      char: 'f',
+      exists: true,
+    }),
+    'update-records': Flags.boolean({
+      summary: 'Update ProductSurcharge records in the org with RuleEngineType=ConstraintEngine.',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<CmlConvertSurchargeRulesResult> {
+    const { flags } = await this.parse(CmlConvertSurchargeRules);
+
+    const workspaceDir = flags['workspace-dir'] ?? '.';
+    const targetOrg = flags['target-org'];
+
+    const records = await this.loadRecords(flags, targetOrg);
+    if (records.length === 0) {
+      this.log('No surcharge rules to convert.');
+      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
+    }
+
+    const ruleDefs = this.parseRuleDefinitions(records);
+    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
+
+    const api = flags['cml-api'] ?? (await this.discoverCmlApi(ruleDefs, productIdToCode, targetOrg, flags));
+    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'SC', 'Surcharge eligibility');
+    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
+
+    if (flags['update-records']) {
+      await this.updateOrgRecords(targetOrg, flags, ruleKeyMapping);
+    }
+
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  private async loadRecords(
+    flags: Record<string, unknown>,
+    targetOrg: { getConnection: (v?: string) => Connection }
+  ): Promise<ProductSurchargeRecord[]> {
+    const surchargeFile = flags['surcharge-file'] as string | undefined;
+    if (surchargeFile) {
+      this.log(`Reading surcharges from file: ${surchargeFile}`);
+      const contents = await fs.readFile(surchargeFile, 'utf8');
+      return JSON.parse(contents) as ProductSurchargeRecord[];
+    }
+
+    this.log('Querying ProductSurcharge records from org...');
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+    const result = await conn.query<ProductSurchargeRecord>(
+      'SELECT Id, Name, RuleApiName, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null'
+    );
+    this.log(`Found ${result.records.length} ProductSurcharge records with BRE rules`);
+    return result.records;
+  }
+
+  private parseRuleDefinitions(
+    records: ProductSurchargeRecord[]
+  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
+    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
+    for (const record of records) {
+      if (!record.RuleDefinition) {
+        this.warn(`Skipping ${record.Name}: no RuleDefinition`);
+        continue;
+      }
+      try {
+        const raw = JSON.parse(record.RuleDefinition) as { ruleApiName?: string; ruleCriteria?: unknown[] };
+        parsed.push({
+          record,
+          ruleDef: {
+            ...raw,
+            name: record.Name,
+            apiName: raw.ruleApiName ?? record.Name,
+            productPath: record.ProductPath,
+          } as ParsedRuleDefinition,
+        });
+      } catch {
+        this.warn(`Failed to parse RuleDefinition for ${record.Name}`);
+      }
+    }
+    this.log(`Parsed ${parsed.length} valid rule definitions`);
+    return parsed;
+  }
+
+  private async discoverCmlApi(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    productIdToCode: Map<string, string>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<string> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      const discovered = await discoverCmlApiByProducts(conn, productIds);
+      if (discovered) {
+        this.log(`Auto-discovered existing CML API: ${discovered}`);
+        return discovered;
+      }
+    } catch (e) {
+      this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
+    }
+
+    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
+    const generated = `SC_${codes.join('_')}`;
+    this.log(`No existing CML found. Generated new CML API name: ${generated}`);
+    return generated;
+  }
+
+  private async resolveProductCodes(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<Map<string, string>> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      return await fetchProductCodes(conn, productIds);
+    } catch (e) {
+      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
+      return new Map<string, string>();
+    }
+  }
+
+  private async updateOrgRecords(
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>,
+    ruleKeyMapping: RuleKeyEntry[]
+  ): Promise<void> {
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+    this.log('\nUpdating ProductSurcharge records with RuleEngineType and RuleKey...');
+    const updates = ruleKeyMapping.map((m) => ({
+      Id: m.recordId,
+      RuleEngineType: 'ConstraintEngine',
+    }));
+    const results = await conn.sobject('ProductSurcharge').update(updates);
+    const successes = (Array.isArray(results) ? results : [results]).filter((r) => r.success);
+    const failures = (Array.isArray(results) ? results : [results]).filter((r) => !r.success);
+    this.log(`  Updated ${successes.length} records successfully`);
+    for (const f of failures) {
+      this.warn(`  Failed to update ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
+    }
+  }
+
+  private async writeOutputFiles(
+    cmlModel: CmlModel,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<CmlConvertSurchargeRulesResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
+    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nCML written to: ${cmlPath}`);
+    this.log(`Associations written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`\nConverted ${ruleKeyMapping.length} rules to CML`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the generated .cml file');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+    this.log('  3. Update records with RuleEngineType and RuleKey from mapping file');
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+  }
+}

--- a/src/commands/cml/convert/underwriting-rules.ts
+++ b/src/commands/cml/convert/underwriting-rules.ts
@@ -13,200 +13,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as fs from 'node:fs/promises';
-import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Connection } from '@salesforce/core';
-import { CmlModel } from '../../../shared/types/types.js';
-import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import { Flags } from '@salesforce/sf-plugins-core';
+import { Connection, Messages } from '@salesforce/core';
 import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
-import { buildCmlModel } from '../../../shared/insurance/insurance-rule-generator.js';
-import { discoverCmlApiByProducts, fetchProductCodes } from '../../../shared/insurance/insurance-org.js';
+import {
+  InsuranceRuleConvertCommand,
+  InsuranceRuleConvertResult,
+} from '../../../shared/insurance/insurance-rule-convert-command.js';
+import { decodeHtmlEntities } from '../../../shared/insurance/insurance-rule-generator.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.underwriting-rules');
 
 type UnderwritingRuleRecord = RuleRecord & {
   ApiName: string | null;
   DynamicRuleDefinition: string | null;
-  Status: string | null;
-  Sequence: number | null;
   RuleKey: string | null;
   UnderwritingRuleGroupId: string | null;
 };
 
-export type CmlConvertUnderwritingRulesResult = {
-  cmlFile: string;
-  associationsFile: string;
-  ruleKeyMapping: RuleKeyEntry[];
-};
+export type CmlConvertUnderwritingRulesResult = InsuranceRuleConvertResult;
 
-export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnderwritingRulesResult> {
-  public static readonly summary =
-    'Converts BRE-based Insurance Underwriting dynamic rules to CML eligibility constraints.';
-  public static readonly description =
-    'Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an _Associations.csv file for ExpressionSetConstraintObj records, and a _RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping for updating records.';
-  public static readonly examples = [
-    '<%= config.bin %> <%= command.id %> --cml-api UW_CML --target-org myOrg',
-    '<%= config.bin %> <%= command.id %> --cml-api UW_CML --uw-file data/underwriting.json --workspace-dir data --target-org myOrg',
-  ];
+// eslint-disable-next-line sf-plugin/only-extend-SfCommand
+export default class CmlConvertUnderwritingRules extends InsuranceRuleConvertCommand<UnderwritingRuleRecord> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
+  public static readonly examples = messages.getMessages('examples');
 
   public static readonly flags = {
-    'target-org': Flags.requiredOrg(),
-    'api-version': Flags.orgApiVersion(),
-    'cml-api': Flags.string({
-      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
-      char: 'c',
-    }),
-    'workspace-dir': Flags.directory({
-      summary: 'Directory where output files will be written.',
-      char: 'd',
-      exists: true,
-    }),
+    ...InsuranceRuleConvertCommand.flags,
     'uw-file': Flags.file({
-      summary:
-        'Optional JSON file with pre-exported UnderwritingRule records. If omitted, records are queried from the org.',
+      summary: messages.getMessage('flags.uw-file.summary'),
       char: 'f',
       exists: true,
     }),
-    'update-records': Flags.boolean({
-      summary:
-        'Update UnderwritingRuleGroup.RuleEngineType to ConstraintEngine and write ruleKey into each UnderwritingRule DynamicRuleDefinition.',
-      default: false,
-    }),
   };
+
+  protected readonly recordLabel = 'UnderwritingRule';
+  protected readonly keyPrefix = 'UW';
+  protected readonly constraintLabel = 'Underwriting eligibility';
+  protected readonly apiNamePrefix = 'UW_';
+  // DynamicRuleDefinition is a non-filterable (long text) field, so it can't appear in the
+  // WHERE clause; records with a null DynamicRuleDefinition are skipped during parsing instead.
+  protected readonly soql =
+    'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, RuleKey, UnderwritingRuleGroupId FROM UnderwritingRule WHERE RuleKey = null';
 
   public async run(): Promise<CmlConvertUnderwritingRulesResult> {
     const { flags } = await this.parse(CmlConvertUnderwritingRules);
-
-    const workspaceDir = flags['workspace-dir'] ?? '.';
-    const targetOrg = flags['target-org'];
-
-    const records = await this.loadRecords(flags, targetOrg);
-    if (records.length === 0) {
-      this.log('No underwriting rules to convert.');
-      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
-    }
-
-    const ruleDefs = this.parseRuleDefinitions(records);
-    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
-
-    const api = flags['cml-api'] ?? (await this.discoverCmlApi(ruleDefs, productIdToCode, targetOrg, flags));
-    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'UW', 'Underwriting eligibility');
-    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
-
-    if (flags['update-records']) {
-      await this.updateRecordsViaConnectApi(records, ruleKeyMapping, targetOrg, flags);
-    }
-
-    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+    return this.runConvert({
+      targetOrg: flags['target-org'],
+      apiVersion: flags['api-version'],
+      cmlApi: flags['cml-api'],
+      workspaceDir: flags['workspace-dir'],
+      inputFile: flags['uw-file'],
+      updateRecords: flags['update-records'],
+    });
   }
 
-  private async loadRecords(
-    flags: Record<string, unknown>,
-    targetOrg: { getConnection: (v?: string) => Connection }
-  ): Promise<UnderwritingRuleRecord[]> {
-    const uwFile = flags['uw-file'] as string | undefined;
-    if (uwFile) {
-      this.log(`Reading underwriting rules from file: ${uwFile}`);
-      const contents = await fs.readFile(uwFile, 'utf8');
-      return JSON.parse(contents) as UnderwritingRuleRecord[];
-    }
-
-    this.log('Querying UnderwritingRule records from org...');
-    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-    const result = await conn.query<UnderwritingRuleRecord>(
-      'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, Status, Sequence, RuleKey, UnderwritingRuleGroupId FROM UnderwritingRule'
-    );
-    this.log(`Found ${result.records.length} UnderwritingRule records with BRE rules`);
-    return result.records;
-  }
-
-  private parseRuleDefinitions(
-    records: UnderwritingRuleRecord[]
-  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
-    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
-    for (const record of records) {
-      if (!record.DynamicRuleDefinition) {
-        this.warn(`Skipping ${record.Name}: no DynamicRuleDefinition`);
-        continue;
-      }
-      try {
-        const raw = JSON.parse(record.DynamicRuleDefinition) as {
-          apiName?: string;
-          name?: string;
-          status?: string;
-          description?: string;
-          productPath?: string;
-          ruleCriteria?: unknown[];
-        };
-        parsed.push({
-          record,
-          ruleDef: {
-            ...raw,
-            name: raw.name ?? record.Name,
-            apiName: raw.apiName ?? record.ApiName ?? record.Name,
-            productPath: raw.productPath ?? record.ProductPath,
-          } as ParsedRuleDefinition,
-        });
-      } catch {
-        this.warn(`Failed to parse DynamicRuleDefinition for ${record.Name}`);
-      }
-    }
-    this.log(`Parsed ${parsed.length} valid rule definitions`);
-    return parsed;
-  }
-
-  private async discoverCmlApi(
-    ruleDefs: Array<{ record: RuleRecord }>,
-    productIdToCode: Map<string, string>,
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>
-  ): Promise<string> {
-    const productIds = new Set<string>();
-    for (const { record } of ruleDefs) {
-      productIds.add(record.ProductPath.split('/')[0]);
+  protected parseRecord(record: UnderwritingRuleRecord): ParsedRuleDefinition | null {
+    if (!record.DynamicRuleDefinition) {
+      this.warn(`Skipping ${record.Name}: no DynamicRuleDefinition`);
+      return null;
     }
     try {
-      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-      const discovered = await discoverCmlApiByProducts(conn, productIds);
-      if (discovered) {
-        this.log(`Auto-discovered existing CML API: ${discovered}`);
-        return discovered;
-      }
-    } catch (e) {
-      this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
-    }
-
-    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
-    const generated = `UW_${codes.join('_')}`;
-    this.log(`No existing CML found. Generated new CML API name: ${generated}`);
-    return generated;
-  }
-
-  private async resolveProductCodes(
-    ruleDefs: Array<{ record: RuleRecord }>,
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>
-  ): Promise<Map<string, string>> {
-    const productIds = new Set<string>();
-    for (const { record } of ruleDefs) {
-      productIds.add(record.ProductPath.split('/')[0]);
-    }
-    try {
-      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-      return await fetchProductCodes(conn, productIds);
-    } catch (e) {
-      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
-      return new Map<string, string>();
+      const raw = JSON.parse(decodeHtmlEntities(record.DynamicRuleDefinition)) as {
+        apiName?: string;
+        name?: string;
+        status?: string;
+        description?: string;
+        productPath?: string;
+        ruleCriteria?: unknown[];
+      };
+      return {
+        ...raw,
+        name: raw.name ?? record.Name,
+        apiName: raw.apiName ?? record.ApiName ?? record.Name,
+        productPath: raw.productPath ?? record.ProductPath,
+      } as ParsedRuleDefinition;
+    } catch {
+      this.warn(`Failed to parse DynamicRuleDefinition for ${record.Name}`);
+      return null;
     }
   }
 
-  private async updateRecordsViaConnectApi(
+  protected async updateOrgRecords(
     records: UnderwritingRuleRecord[],
     ruleKeyMapping: RuleKeyEntry[],
-    targetOrg: { getConnection: (v?: string) => Connection },
-    flags: Record<string, unknown>
+    conn: Connection
   ): Promise<void> {
-    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
-
     const groupIds = new Set<string>();
     for (const record of records) {
       if (record.UnderwritingRuleGroupId) {
@@ -221,8 +115,9 @@ export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnd
         RuleEngineType: 'ConstraintEngine',
       }));
       const groupResults = await conn.sobject('UnderwritingRuleGroup').update(groupUpdates);
-      const groupSuccesses = (Array.isArray(groupResults) ? groupResults : [groupResults]).filter((r) => r.success);
-      const groupFailures = (Array.isArray(groupResults) ? groupResults : [groupResults]).filter((r) => !r.success);
+      const groupList = Array.isArray(groupResults) ? groupResults : [groupResults];
+      const groupSuccesses = groupList.filter((r) => r.success);
+      const groupFailures = groupList.filter((r) => !r.success);
       this.log(`  Updated ${groupSuccesses.length} group records`);
       for (const f of groupFailures) {
         this.warn(`  Failed to update group ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
@@ -274,34 +169,5 @@ export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnd
     }
 
     this.log(`  Updated ${successCount} rule records, ${failCount} failed`);
-  }
-
-  private async writeOutputFiles(
-    cmlModel: CmlModel,
-    ruleKeyMapping: RuleKeyEntry[],
-    safeApi: string,
-    workspaceDir: string,
-    api: string
-  ): Promise<CmlConvertUnderwritingRulesResult> {
-    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
-    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
-    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
-
-    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
-    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
-    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
-
-    this.log(`\nCML written to: ${cmlPath}`);
-    this.log(`Associations written to: ${associationsPath}`);
-    this.log(`Rule key mapping written to: ${mappingPath}`);
-    this.log(`\nConverted ${ruleKeyMapping.length} underwriting rules to CML`);
-    this.log('\nNext steps:');
-    this.log('  1. Review the generated .cml file');
-    this.log(
-      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
-    );
-    this.log('  3. Update UnderwritingRule records with RuleKey from mapping file');
-
-    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
   }
 }

--- a/src/commands/cml/convert/underwriting-rules.ts
+++ b/src/commands/cml/convert/underwriting-rules.ts
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from 'node:fs/promises';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Connection } from '@salesforce/core';
+import { CmlModel } from '../../../shared/types/types.js';
+import { generateCsvForAssociations } from '../../../shared/utils/association.utils.js';
+import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
+import { buildCmlModel } from '../../../shared/insurance/insurance-rule-generator.js';
+import { discoverCmlApiByProducts, fetchProductCodes } from '../../../shared/insurance/insurance-org.js';
+
+type UnderwritingRuleRecord = RuleRecord & {
+  ApiName: string | null;
+  DynamicRuleDefinition: string | null;
+  Status: string | null;
+  Sequence: number | null;
+  RuleKey: string | null;
+  UnderwritingRuleGroupId: string | null;
+};
+
+export type CmlConvertUnderwritingRulesResult = {
+  cmlFile: string;
+  associationsFile: string;
+  ruleKeyMapping: RuleKeyEntry[];
+};
+
+export default class CmlConvertUnderwritingRules extends SfCommand<CmlConvertUnderwritingRulesResult> {
+  public static readonly summary =
+    'Converts BRE-based Insurance Underwriting dynamic rules to CML eligibility constraints.';
+  public static readonly description =
+    'Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an _Associations.csv file for ExpressionSetConstraintObj records, and a _RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping for updating records.';
+  public static readonly examples = [
+    '<%= config.bin %> <%= command.id %> --cml-api UW_CML --target-org myOrg',
+    '<%= config.bin %> <%= command.id %> --cml-api UW_CML --uw-file data/underwriting.json --workspace-dir data --target-org myOrg',
+  ];
+
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'cml-api': Flags.string({
+      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
+      char: 'c',
+    }),
+    'workspace-dir': Flags.directory({
+      summary: 'Directory where output files will be written.',
+      char: 'd',
+      exists: true,
+    }),
+    'uw-file': Flags.file({
+      summary:
+        'Optional JSON file with pre-exported UnderwritingRule records. If omitted, records are queried from the org.',
+      char: 'f',
+      exists: true,
+    }),
+    'update-records': Flags.boolean({
+      summary:
+        'Update UnderwritingRuleGroup.RuleEngineType to ConstraintEngine and write ruleKey into each UnderwritingRule DynamicRuleDefinition.',
+      default: false,
+    }),
+  };
+
+  public async run(): Promise<CmlConvertUnderwritingRulesResult> {
+    const { flags } = await this.parse(CmlConvertUnderwritingRules);
+
+    const workspaceDir = flags['workspace-dir'] ?? '.';
+    const targetOrg = flags['target-org'];
+
+    const records = await this.loadRecords(flags, targetOrg);
+    if (records.length === 0) {
+      this.log('No underwriting rules to convert.');
+      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
+    }
+
+    const ruleDefs = this.parseRuleDefinitions(records);
+    const productIdToCode = await this.resolveProductCodes(ruleDefs, targetOrg, flags);
+
+    const api = flags['cml-api'] ?? (await this.discoverCmlApi(ruleDefs, productIdToCode, targetOrg, flags));
+    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, 'UW', 'Underwriting eligibility');
+    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
+
+    if (flags['update-records']) {
+      await this.updateRecordsViaConnectApi(records, ruleKeyMapping, targetOrg, flags);
+    }
+
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  private async loadRecords(
+    flags: Record<string, unknown>,
+    targetOrg: { getConnection: (v?: string) => Connection }
+  ): Promise<UnderwritingRuleRecord[]> {
+    const uwFile = flags['uw-file'] as string | undefined;
+    if (uwFile) {
+      this.log(`Reading underwriting rules from file: ${uwFile}`);
+      const contents = await fs.readFile(uwFile, 'utf8');
+      return JSON.parse(contents) as UnderwritingRuleRecord[];
+    }
+
+    this.log('Querying UnderwritingRule records from org...');
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+    const result = await conn.query<UnderwritingRuleRecord>(
+      'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, Status, Sequence, RuleKey, UnderwritingRuleGroupId FROM UnderwritingRule'
+    );
+    this.log(`Found ${result.records.length} UnderwritingRule records with BRE rules`);
+    return result.records;
+  }
+
+  private parseRuleDefinitions(
+    records: UnderwritingRuleRecord[]
+  ): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
+    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
+    for (const record of records) {
+      if (!record.DynamicRuleDefinition) {
+        this.warn(`Skipping ${record.Name}: no DynamicRuleDefinition`);
+        continue;
+      }
+      try {
+        const raw = JSON.parse(record.DynamicRuleDefinition) as {
+          apiName?: string;
+          name?: string;
+          status?: string;
+          description?: string;
+          productPath?: string;
+          ruleCriteria?: unknown[];
+        };
+        parsed.push({
+          record,
+          ruleDef: {
+            ...raw,
+            name: raw.name ?? record.Name,
+            apiName: raw.apiName ?? record.ApiName ?? record.Name,
+            productPath: raw.productPath ?? record.ProductPath,
+          } as ParsedRuleDefinition,
+        });
+      } catch {
+        this.warn(`Failed to parse DynamicRuleDefinition for ${record.Name}`);
+      }
+    }
+    this.log(`Parsed ${parsed.length} valid rule definitions`);
+    return parsed;
+  }
+
+  private async discoverCmlApi(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    productIdToCode: Map<string, string>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<string> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      const discovered = await discoverCmlApiByProducts(conn, productIds);
+      if (discovered) {
+        this.log(`Auto-discovered existing CML API: ${discovered}`);
+        return discovered;
+      }
+    } catch (e) {
+      this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
+    }
+
+    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
+    const generated = `UW_${codes.join('_')}`;
+    this.log(`No existing CML found. Generated new CML API name: ${generated}`);
+    return generated;
+  }
+
+  private async resolveProductCodes(
+    ruleDefs: Array<{ record: RuleRecord }>,
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<Map<string, string>> {
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      productIds.add(record.ProductPath.split('/')[0]);
+    }
+    try {
+      const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+      return await fetchProductCodes(conn, productIds);
+    } catch (e) {
+      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
+      return new Map<string, string>();
+    }
+  }
+
+  private async updateRecordsViaConnectApi(
+    records: UnderwritingRuleRecord[],
+    ruleKeyMapping: RuleKeyEntry[],
+    targetOrg: { getConnection: (v?: string) => Connection },
+    flags: Record<string, unknown>
+  ): Promise<void> {
+    const conn = targetOrg.getConnection(flags['api-version'] as string | undefined);
+
+    const groupIds = new Set<string>();
+    for (const record of records) {
+      if (record.UnderwritingRuleGroupId) {
+        groupIds.add(record.UnderwritingRuleGroupId);
+      }
+    }
+
+    if (groupIds.size > 0) {
+      this.log(`\nUpdating ${groupIds.size} UnderwritingRuleGroup records with RuleEngineType=ConstraintEngine...`);
+      const groupUpdates = Array.from(groupIds).map((id) => ({
+        Id: id,
+        RuleEngineType: 'ConstraintEngine',
+      }));
+      const groupResults = await conn.sobject('UnderwritingRuleGroup').update(groupUpdates);
+      const groupSuccesses = (Array.isArray(groupResults) ? groupResults : [groupResults]).filter((r) => r.success);
+      const groupFailures = (Array.isArray(groupResults) ? groupResults : [groupResults]).filter((r) => !r.success);
+      this.log(`  Updated ${groupSuccesses.length} group records`);
+      for (const f of groupFailures) {
+        this.warn(`  Failed to update group ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
+      }
+    }
+
+    const ruleKeyMap = new Map(ruleKeyMapping.map((m) => [m.recordId, m.ruleKey]));
+    const breRecords = records.filter((r) => !r.RuleKey && r.DynamicRuleDefinition);
+
+    if (breRecords.length === 0) {
+      this.log('\nNo BRE rules to update with RuleKey.');
+      return;
+    }
+
+    this.log(
+      `\nUpdating ${breRecords.length} UnderwritingRule DynamicRuleDefinition with ruleKey and ruleEngineType...`
+    );
+    let successCount = 0;
+    let failCount = 0;
+
+    const updates: Array<{ Id: string; DynamicRuleDefinition: string }> = [];
+    for (const record of breRecords) {
+      const ruleKey = ruleKeyMap.get(record.Id);
+      if (!ruleKey || !record.DynamicRuleDefinition) continue;
+
+      try {
+        const defn = JSON.parse(record.DynamicRuleDefinition) as Record<string, unknown>;
+        defn.ruleKey = ruleKey;
+        if (defn.underwritingRuleGroup && typeof defn.underwritingRuleGroup === 'object') {
+          (defn.underwritingRuleGroup as Record<string, unknown>).ruleEngineType = 'ConstraintEngine';
+        }
+        updates.push({ Id: record.Id, DynamicRuleDefinition: JSON.stringify(defn) });
+      } catch {
+        this.warn(`  Failed to parse DynamicRuleDefinition for ${record.Name}`);
+        failCount++;
+      }
+    }
+
+    if (updates.length > 0) {
+      const results = await conn.sobject('UnderwritingRule').update(updates);
+      for (const r of Array.isArray(results) ? results : [results]) {
+        if (r.success) {
+          successCount++;
+        } else {
+          failCount++;
+          this.warn(`  Failed to update ${r.id ?? 'unknown'}: ${JSON.stringify(r.errors)}`);
+        }
+      }
+    }
+
+    this.log(`  Updated ${successCount} rule records, ${failCount} failed`);
+  }
+
+  private async writeOutputFiles(
+    cmlModel: CmlModel,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<CmlConvertUnderwritingRulesResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
+    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nCML written to: ${cmlPath}`);
+    this.log(`Associations written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`\nConverted ${ruleKeyMapping.length} underwriting rules to CML`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the generated .cml file');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+    this.log('  3. Update UnderwritingRule records with RuleKey from mapping file');
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+  }
+}

--- a/src/shared/bre-rules-generator.ts
+++ b/src/shared/bre-rules-generator.ts
@@ -25,9 +25,10 @@ import {
   CmlType,
   VIRTUAL_QUOTE_TYPE_NAME,
 } from './types/types.js';
-import { Condition, ConfiguratorRuleInput, RuleAction, RuleConditionOperator, RuleCriteria } from './models.js';
+import { Condition, ConfiguratorRuleInput, RuleAction, RuleCriteria } from './models.js';
 import { PcmGenerator } from './pcm-generator.js';
 import { Logger } from './utils/common.utils.js';
+import { convertToCmlExpression, doubleQuoted } from './cml-operators.js';
 
 const INT_TAGS = ['LineItemQuantity'];
 
@@ -477,74 +478,6 @@ function getTargetAttribute(
     }
   }
   return targetAttribute;
-}
-
-function doubleQuotedIfNeeded(value: string | string[] | undefined, dataType: string | undefined): string {
-  if (typeof value === 'string' || typeof value === 'undefined') {
-    return `${dataType === 'string' ? doubleQuoted(value) ?? '' : value ?? "''"}`;
-  }
-  const singleValue = value[0];
-  return `${dataType === 'string' ? doubleQuoted(singleValue) ?? '' : singleValue ?? "''"}`;
-}
-
-function doubleQuoted(str: string | undefined): string {
-  if (str) {
-    return `"${escapeQuotes(str)}"`;
-  }
-  return str ?? "''";
-}
-
-function escapeQuotes(str: string): string {
-  return str.replace(/['"]/g, '\\$&');
-}
-
-function convertToCmlExpression(
-  left: string,
-  ruleExprOperator: RuleConditionOperator,
-  right?: string | string[],
-  dataType?: string
-): string {
-  switch (ruleExprOperator) {
-    case 'Equals':
-      return `${left} == ${doubleQuotedIfNeeded(right, dataType)}`;
-    case 'NotEquals':
-      return `${left} != ${doubleQuotedIfNeeded(right, dataType)}`;
-    case 'LessThan':
-      return `${left} <= ${(right as string | undefined) ?? ''}`;
-    case 'LessThanOrEquals':
-      return `${left} <= ${(right as string | undefined) ?? ''}`;
-    case 'GreaterThan':
-      return `${left} > ${(right as string | undefined) ?? ''}`;
-    case 'GreaterThanOrEquals':
-      return `${left} >= ${(right as string | undefined) ?? ''}`;
-    case 'IsNotNull':
-      return `${left} != null`;
-    case 'IsNull':
-      return `${left} == null`;
-    case 'Contains':
-      return `strcontain(${left}, ${doubleQuoted(right as string | undefined)})`;
-    case 'DoesNotContain':
-      return `!strcontain(${left}, ${doubleQuoted(right as string | undefined)})`;
-    case 'In':
-      if (right) {
-        return `(${generateInCmlExpression(left, right)})`;
-      }
-      return `${left} == null`;
-    case 'NotIn':
-      if (right) {
-        return `!(${generateInCmlExpression(left, right)})`;
-      }
-      return `${left} != null`;
-  }
-
-  //  throw new Error(`Operator ${ruleExprOperator} is not supported.`);
-}
-
-function generateInCmlExpression(left: string, right: string | string[]): string {
-  if (typeof right === 'string') {
-    return `${left} == ${doubleQuoted(right)}`;
-  }
-  return `${right.map((r) => `${left} == ${doubleQuoted(r)}`).join(' || ')}`;
 }
 
 export class BreRulesGenerator {

--- a/src/shared/cml-operators.ts
+++ b/src/shared/cml-operators.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { RuleConditionOperator } from './models.js';
+
+export function escapeQuotes(str: string): string {
+  return str.replace(/['"]/g, '\\$&');
+}
+
+export function doubleQuoted(str: string | undefined): string {
+  if (str) {
+    return `"${escapeQuotes(str)}"`;
+  }
+  return str ?? "''";
+}
+
+export function doubleQuotedIfNeeded(value: string | string[] | undefined, dataType: string | undefined): string {
+  if (typeof value === 'string' || typeof value === 'undefined') {
+    return `${dataType === 'string' ? doubleQuoted(value) ?? '' : value ?? "''"}`;
+  }
+  const singleValue = value[0];
+  return `${dataType === 'string' ? doubleQuoted(singleValue) ?? '' : singleValue ?? "''"}`;
+}
+
+export function generateInCmlExpression(left: string, right: string | string[]): string {
+  if (typeof right === 'string') {
+    return `${left} == ${doubleQuoted(right)}`;
+  }
+  return right.map((r) => `${left} == ${doubleQuoted(r)}`).join(' || ');
+}
+
+function firstValue(right: string | string[] | undefined): string | undefined {
+  if (right === undefined) return undefined;
+  return typeof right === 'string' ? right : right[0];
+}
+
+export function convertToCmlExpression(
+  left: string,
+  ruleExprOperator: RuleConditionOperator,
+  right?: string | string[],
+  dataType?: string
+): string {
+  switch (ruleExprOperator) {
+    case 'Equals':
+      return `${left} == ${doubleQuotedIfNeeded(right, dataType)}`;
+    case 'NotEquals':
+      return `${left} != ${doubleQuotedIfNeeded(right, dataType)}`;
+    case 'LessThan':
+      return `${left} < ${(right as string | undefined) ?? ''}`;
+    case 'LessThanOrEquals':
+      return `${left} <= ${(right as string | undefined) ?? ''}`;
+    case 'GreaterThan':
+      return `${left} > ${(right as string | undefined) ?? ''}`;
+    case 'GreaterThanOrEquals':
+      return `${left} >= ${(right as string | undefined) ?? ''}`;
+    case 'IsNotNull':
+      return `${left} != null`;
+    case 'IsNull':
+      return `${left} == null`;
+    case 'Contains':
+      return `strcontain(${left}, ${doubleQuoted(firstValue(right))})`;
+    case 'DoesNotContain':
+      return `!strcontain(${left}, ${doubleQuoted(firstValue(right))})`;
+    case 'In':
+      if (right) {
+        return `(${generateInCmlExpression(left, right)})`;
+      }
+      return `${left} == null`;
+    case 'NotIn':
+      if (right) {
+        return `!(${generateInCmlExpression(left, right)})`;
+      }
+      return `${left} != null`;
+    default: {
+      const exhaustive: never = ruleExprOperator;
+      throw new Error(`Unsupported rule operator: ${String(exhaustive)}`);
+    }
+  }
+}
+
+const KNOWN_OPERATORS: ReadonlySet<string> = new Set<RuleConditionOperator>([
+  'Equals',
+  'NotEquals',
+  'LessThan',
+  'LessThanOrEquals',
+  'GreaterThan',
+  'GreaterThanOrEquals',
+  'IsNotNull',
+  'IsNull',
+  'Contains',
+  'DoesNotContain',
+  'In',
+  'NotIn',
+]);
+
+export function isKnownOperator(op: string): op is RuleConditionOperator {
+  return KNOWN_OPERATORS.has(op);
+}
+
+const NULL_OPERATORS: ReadonlySet<RuleConditionOperator> = new Set(['IsNull', 'IsNotNull']);
+
+export function operatorRequiresValues(op: RuleConditionOperator): boolean {
+  return !NULL_OPERATORS.has(op);
+}

--- a/src/shared/insurance/insurance-org.ts
+++ b/src/shared/insurance/insurance-org.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Connection } from '@salesforce/core';
+
+export async function fetchProductCodes(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
+  const idToCode = new Map<string, string>();
+  if (productIds.size === 0) return idToCode;
+
+  const idList = Array.from(productIds)
+    .map((id) => `'${id}'`)
+    .join(',');
+  const result = await conn.query<{ Id: string; ProductCode: string; Name: string }>(
+    `SELECT Id, ProductCode, Name FROM Product2 WHERE Id IN (${idList})`
+  );
+  for (const p of result.records) {
+    idToCode.set(p.Id, p.ProductCode ?? p.Name ?? p.Id);
+  }
+  return idToCode;
+}
+
+export async function discoverCmlApiByProducts(conn: Connection, productIds: Set<string>): Promise<string | undefined> {
+  if (productIds.size === 0) return undefined;
+
+  const idList = Array.from(productIds)
+    .map((id) => `'${id}'`)
+    .join(',');
+  const assocResult = await conn.query<{ ExpressionSetId: string }>(
+    `SELECT ExpressionSetId FROM ExpressionSetConstraintObj WHERE ReferenceObjectId IN (${idList}) AND ConstraintModelTagType = 'Type' LIMIT 1`
+  );
+  if (assocResult.records.length === 0) return undefined;
+
+  const esId = assocResult.records[0].ExpressionSetId;
+  const esResult = await conn.query<{ ApiName: string }>(`SELECT ApiName FROM ExpressionSet WHERE Id = '${esId}'`);
+  if (esResult.records.length === 0) return undefined;
+
+  return esResult.records[0].ApiName;
+}

--- a/src/shared/insurance/insurance-org.ts
+++ b/src/shared/insurance/insurance-org.ts
@@ -15,13 +15,26 @@
  */
 import { Connection } from '@salesforce/core';
 
-export async function fetchProductCodes(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
-  const idToCode = new Map<string, string>();
-  if (productIds.size === 0) return idToCode;
+/** Matches a well-formed 15- or 18-character Salesforce record id. */
+const SALESFORCE_ID_PATTERN = /^[a-zA-Z0-9]{15,18}$/;
 
-  const idList = Array.from(productIds)
+/**
+ * Builds a quoted, comma-separated SOQL id list, keeping only well-formed Salesforce ids.
+ * Product ids originate from rule definitions that may be supplied via --surcharge-file /
+ * --uw-file, so validating here prevents SOQL injection through the `IN (...)` clause.
+ */
+export function quoteSoqlIdList(ids: Iterable<string>): string {
+  return Array.from(ids)
+    .filter((id) => SALESFORCE_ID_PATTERN.test(id))
     .map((id) => `'${id}'`)
     .join(',');
+}
+
+export async function fetchProductCodes(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
+  const idToCode = new Map<string, string>();
+  const idList = quoteSoqlIdList(productIds);
+  if (!idList) return idToCode;
+
   const result = await conn.query<{ Id: string; ProductCode: string; Name: string }>(
     `SELECT Id, ProductCode, Name FROM Product2 WHERE Id IN (${idList})`
   );
@@ -32,17 +45,17 @@ export async function fetchProductCodes(conn: Connection, productIds: Set<string
 }
 
 export async function discoverCmlApiByProducts(conn: Connection, productIds: Set<string>): Promise<string | undefined> {
-  if (productIds.size === 0) return undefined;
+  const idList = quoteSoqlIdList(productIds);
+  if (!idList) return undefined;
 
-  const idList = Array.from(productIds)
-    .map((id) => `'${id}'`)
-    .join(',');
   const assocResult = await conn.query<{ ExpressionSetId: string }>(
     `SELECT ExpressionSetId FROM ExpressionSetConstraintObj WHERE ReferenceObjectId IN (${idList}) AND ConstraintModelTagType = 'Type' LIMIT 1`
   );
   if (assocResult.records.length === 0) return undefined;
 
   const esId = assocResult.records[0].ExpressionSetId;
+  if (!SALESFORCE_ID_PATTERN.test(esId)) return undefined;
+
   const esResult = await conn.query<{ ApiName: string }>(`SELECT ApiName FROM ExpressionSet WHERE Id = '${esId}'`);
   if (esResult.records.length === 0) return undefined;
 

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -18,12 +18,15 @@
 // command-shape lint rules do not apply.
 import * as fs from 'node:fs/promises';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
-import { Connection, Org } from '@salesforce/core';
+import { Connection, Messages, Org } from '@salesforce/core';
 import { CmlModel } from '../types/types.js';
 import { generateCsvForAssociations } from '../utils/association.utils.js';
 import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from './models.js';
 import { buildCmlModel } from './insurance-rule-generator.js';
 import { discoverCmlApiByProducts, fetchProductCodes } from './insurance-org.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.insurance-shared');
 
 export type InsuranceRuleConvertResult = {
   cmlFile: string;
@@ -45,16 +48,16 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     'target-org': Flags.requiredOrg(),
     'api-version': Flags.orgApiVersion(),
     'cml-api': Flags.string({
-      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
+      summary: messages.getMessage('flags.cml-api.summary'),
       char: 'c',
     }),
     'workspace-dir': Flags.directory({
-      summary: 'Directory where output files will be written.',
+      summary: messages.getMessage('flags.workspace-dir.summary'),
       char: 'd',
       exists: true,
     }),
     'update-records': Flags.boolean({
-      summary: 'Update source records in the org with RuleEngineType=ConstraintEngine.',
+      summary: messages.getMessage('flags.update-records.summary'),
       default: false,
     }),
   };

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable sf-plugin/command-summary, sf-plugin/command-example, sf-plugin/no-hardcoded-messages-commands */
+// This file is a shared abstract base, not a user-invocable command, so the
+// command-shape lint rules do not apply.
+import * as fs from 'node:fs/promises';
+import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
+import { Connection, Org } from '@salesforce/core';
+import { CmlModel } from '../types/types.js';
+import { generateCsvForAssociations } from '../utils/association.utils.js';
+import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from './models.js';
+import { buildCmlModel } from './insurance-rule-generator.js';
+import { discoverCmlApiByProducts, fetchProductCodes } from './insurance-org.js';
+
+export type InsuranceRuleConvertResult = {
+  cmlFile: string;
+  associationsFile: string;
+  ruleKeyMapping: RuleKeyEntry[];
+};
+
+export type InsuranceRuleConvertContext = {
+  targetOrg: Org;
+  apiVersion: string | undefined;
+  cmlApi: string | undefined;
+  workspaceDir: string | undefined;
+  inputFile: string | undefined;
+  updateRecords: boolean;
+};
+
+export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends SfCommand<InsuranceRuleConvertResult> {
+  public static readonly flags = {
+    'target-org': Flags.requiredOrg(),
+    'api-version': Flags.orgApiVersion(),
+    'cml-api': Flags.string({
+      summary: 'CML API Name. If omitted, auto-discovers an existing CML associated with the same root products.',
+      char: 'c',
+    }),
+    'workspace-dir': Flags.directory({
+      summary: 'Directory where output files will be written.',
+      char: 'd',
+      exists: true,
+    }),
+    'update-records': Flags.boolean({
+      summary: 'Update source records in the org with RuleEngineType=ConstraintEngine.',
+      default: false,
+    }),
+  };
+
+  protected abstract readonly recordLabel: string;
+  protected abstract readonly keyPrefix: string;
+  protected abstract readonly constraintLabel: string;
+  protected abstract readonly apiNamePrefix: string;
+  protected abstract readonly soql: string;
+
+  protected async runConvert(ctx: InsuranceRuleConvertContext): Promise<InsuranceRuleConvertResult> {
+    const workspaceDir = ctx.workspaceDir ?? '.';
+    this.log(`Using Workspace Directory: ${ctx.workspaceDir ?? 'not specified'}`);
+    const conn = ctx.targetOrg.getConnection(ctx.apiVersion);
+
+    const records = await this.loadRecords(conn, ctx.inputFile);
+    if (records.length === 0) {
+      this.log(`No ${this.recordLabel} rules to convert.`);
+      return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
+    }
+
+    const ruleDefs = this.parseAllRecords(records);
+    const productIdToCode = await this.resolveProductCodes(conn, ruleDefs);
+
+    const api = ctx.cmlApi ?? (await this.discoverCmlApi(conn, ruleDefs, productIdToCode));
+    const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, this.keyPrefix, this.constraintLabel);
+    ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
+
+    if (ctx.updateRecords) {
+      await this.updateOrgRecords(records, ruleKeyMapping, conn);
+    }
+
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  private async loadRecords(conn: Connection, inputFile: string | undefined): Promise<R[]> {
+    if (inputFile) {
+      this.log(`Reading ${this.recordLabel} records from file: ${inputFile}`);
+      const contents = await fs.readFile(inputFile, 'utf8');
+      return JSON.parse(contents) as R[];
+    }
+
+    this.log(`Querying ${this.recordLabel} records from org...`);
+    const result = await conn.query<R>(this.soql);
+    this.log(`Found ${result.records.length} ${this.recordLabel} records with BRE rules`);
+    return result.records;
+  }
+
+  private parseAllRecords(records: R[]): Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> {
+    const parsed: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }> = [];
+    for (const record of records) {
+      try {
+        const ruleDef = this.parseRecord(record);
+        if (ruleDef) {
+          parsed.push({ record, ruleDef });
+        }
+      } catch (e) {
+        this.warn(`Failed to convert ${record.Name}: ${(e as Error).message}`);
+      }
+    }
+    this.log(`Parsed ${parsed.length} valid rule definitions`);
+    return parsed;
+  }
+
+  private async resolveProductCodes(
+    conn: Connection,
+    ruleDefs: Array<{ record: RuleRecord }>
+  ): Promise<Map<string, string>> {
+    const productIds = collectRootProductIds(ruleDefs);
+    try {
+      return await fetchProductCodes(conn, productIds);
+    } catch (e) {
+      this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
+      return new Map<string, string>();
+    }
+  }
+
+  private async discoverCmlApi(
+    conn: Connection,
+    ruleDefs: Array<{ record: RuleRecord }>,
+    productIdToCode: Map<string, string>
+  ): Promise<string> {
+    const productIds = collectRootProductIds(ruleDefs);
+    try {
+      const discovered = await discoverCmlApiByProducts(conn, productIds);
+      if (discovered) {
+        this.log(`Auto-discovered existing CML API: ${discovered}`);
+        return discovered;
+      }
+    } catch (e) {
+      this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
+    }
+
+    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
+    const generated = `${this.apiNamePrefix}${codes.join('_')}`;
+    this.log(`No existing CML found. Generated new CML API name: ${generated}`);
+    return generated;
+  }
+
+  private async writeOutputFiles(
+    cmlModel: CmlModel,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<InsuranceRuleConvertResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
+    await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nCML written to: ${cmlPath}`);
+    this.log(`Associations written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`\nConverted ${ruleKeyMapping.length} ${this.recordLabel} rules to CML`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the generated .cml file');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+    this.log('  3. Update records with RuleKey from mapping file');
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+  }
+
+  protected abstract parseRecord(record: R): ParsedRuleDefinition | null;
+  protected abstract updateOrgRecords(records: R[], ruleKeyMapping: RuleKeyEntry[], conn: Connection): Promise<void>;
+}
+
+function collectRootProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<string> {
+  const productIds = new Set<string>();
+  for (const { record } of ruleDefs) {
+    productIds.add(record.ProductPath.split('/')[0]);
+  }
+  return productIds;
+}

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ASSOCIATION_TYPES, CML_DATA_TYPES, CONSTRAINT_TYPES } from '../constants/constants.js';
+import { Association, CmlAttribute, CmlConstraint, CmlModel, CmlType } from '../types/types.js';
+import {
+  ParsedRuleDefinition,
+  RuleCondition,
+  RuleCriteria,
+  RuleKeyEntry,
+  RuleRecord,
+  UnderwritingRuleGroup,
+} from './models.js';
+
+function operatorToCml(op: string): string {
+  const operators: Record<string, string> = {
+    Equals: '==',
+    NotEquals: '!=',
+    LessThan: '<',
+    LessThanOrEquals: '<=',
+    GreaterThan: '>',
+    GreaterThanOrEquals: '>=',
+    Contains: '.contains',
+    In: '==',
+  };
+  return operators[op] ?? '==';
+}
+
+function dataTypeToCml(dataType?: string): string {
+  const types: Record<string, string> = {
+    Number: CML_DATA_TYPES.INTEGER,
+    Integer: CML_DATA_TYPES.INTEGER,
+    Percent: CML_DATA_TYPES.DECIMAL,
+    Currency: CML_DATA_TYPES.DECIMAL,
+    Boolean: CML_DATA_TYPES.BOOLEAN,
+    Date: CML_DATA_TYPES.DATE,
+    DateTime: CML_DATA_TYPES.DATE,
+  };
+  return (dataType && types[dataType]) ?? CML_DATA_TYPES.STRING;
+}
+
+export function sanitizeName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+function stripSpaces(stage: string): string {
+  return stage.replace(/\s+/g, '');
+}
+
+export function buildStageTransition(ruleGroup?: UnderwritingRuleGroup): string | undefined {
+  if (!ruleGroup?.fromStage || !ruleGroup?.toStage) return undefined;
+  return `${stripSpaces(ruleGroup.fromStage)}To${stripSpaces(ruleGroup.toStage)}`;
+}
+
+export function generateRuleKey(
+  prefix: string,
+  productCode: string,
+  apiName: string,
+  stageTransition?: string
+): string {
+  const parts = [prefix, sanitizeName(productCode)];
+  if (stageTransition) parts.push(stageTransition);
+  parts.push(sanitizeName(apiName));
+  return parts.join('__');
+}
+
+function buildConditionExpression(condition: RuleCondition): string | null {
+  if (!condition.values || condition.values.length === 0) return null;
+
+  const attrName = sanitizeName(condition.attributeName ?? condition.contextTagName ?? 'unknown');
+  const op = operatorToCml(condition.operator);
+  const value = condition.values[0];
+  const cmlDataType = dataTypeToCml(condition.dataType);
+  const isNumeric = cmlDataType === CML_DATA_TYPES.INTEGER || cmlDataType === CML_DATA_TYPES.DECIMAL;
+  const quotedValue = isNumeric ? value : `"${value}"`;
+
+  return `${attrName} ${op} ${quotedValue}`;
+}
+
+function buildCriteriaExpression(criteria: RuleCriteria): string | null {
+  const parts: string[] = [];
+
+  if (criteria.conditions) {
+    for (const condition of criteria.conditions) {
+      const expr = buildConditionExpression(condition);
+      if (expr) parts.push(expr);
+    }
+  }
+
+  return parts.length > 0 ? parts.join(' && ') : null;
+}
+
+export function buildConstraintDeclaration(ruleDef: { ruleCriteria?: RuleCriteria[] }): string {
+  if (!ruleDef.ruleCriteria || ruleDef.ruleCriteria.length === 0) {
+    return 'true';
+  }
+
+  const expressions = ruleDef.ruleCriteria.map(buildCriteriaExpression).filter((e): e is string => e !== null);
+
+  if (expressions.length === 0) return 'true';
+  if (expressions.length === 1) return expressions[0];
+  return expressions.map((e) => `(${e})`).join(' || ');
+}
+
+export function collectAttributes(ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>): Set<string> {
+  const attrs = new Set<string>();
+  for (const { ruleDef } of ruleDefs) {
+    for (const criteria of ruleDef.ruleCriteria ?? []) {
+      for (const cond of criteria.conditions ?? []) {
+        const name = cond.attributeName ?? cond.contextTagName;
+        if (name) attrs.add(name);
+      }
+    }
+  }
+  return attrs;
+}
+
+export function buildCmlModel(
+  ruleDefs: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>,
+  productIdToCode: Map<string, string>,
+  keyPrefix: string,
+  constraintLabel: string
+): { cmlModel: CmlModel; ruleKeyMapping: RuleKeyEntry[] } {
+  const cmlModel = new CmlModel();
+
+  const rulesByProduct = new Map<string, Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>>();
+  for (const entry of ruleDefs) {
+    const rootProductId = entry.record.ProductPath.split('/')[0];
+    if (!rulesByProduct.has(rootProductId)) {
+      rulesByProduct.set(rootProductId, []);
+    }
+    rulesByProduct.get(rootProductId)!.push(entry);
+  }
+
+  const ruleKeyMapping: RuleKeyEntry[] = [];
+
+  for (const [rootProductId, productRules] of rulesByProduct) {
+    const productCode = productIdToCode.get(rootProductId) ?? rootProductId;
+    const typeName = sanitizeName(productCode);
+    const productType = new CmlType(typeName, undefined, undefined);
+
+    const attrs = collectAttributes(productRules);
+    for (const attrName of attrs) {
+      productType.addAttribute(new CmlAttribute(null, sanitizeName(attrName), CML_DATA_TYPES.STRING));
+    }
+
+    for (const { record, ruleDef } of productRules) {
+      const apiName = ruleDef.apiName ?? record.Name;
+      const stageTransition = buildStageTransition(ruleDef.underwritingRuleGroup);
+      const ruleKey = generateRuleKey(keyPrefix, productCode, apiName, stageTransition);
+
+      const constraint = new CmlConstraint(
+        CONSTRAINT_TYPES.CONSTRAINT,
+        buildConstraintDeclaration(ruleDef),
+        `"${constraintLabel}: ${record.Name}"`
+      );
+      constraint.name = sanitizeName(apiName);
+      productType.addConstraint(constraint);
+
+      ruleKeyMapping.push({ recordId: record.Id, name: record.Name, ruleKey });
+    }
+
+    cmlModel.addType(productType);
+    cmlModel.addAssociation(
+      new Association(null, typeName, ASSOCIATION_TYPES.TYPE, rootProductId, 'Product2', productCode)
+    );
+  }
+
+  return { cmlModel, ruleKeyMapping };
+}

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -168,7 +168,9 @@ export function buildCmlModel(
         buildConstraintDeclaration(ruleDef),
         `"${constraintLabel}: ${record.Name}"`
       );
-      constraint.name = sanitizeName(apiName);
+      // Mirror generateRuleKey: include the stage transition so two rules that share an
+      // apiName under the same product (gated on different transitions) don't collide.
+      constraint.name = sanitizeName(stageTransition ? `${apiName}_${stageTransition}` : apiName);
       productType.addConstraint(constraint);
 
       ruleKeyMapping.push({ recordId: record.Id, name: record.Name, ruleKey });

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -15,6 +15,7 @@
  */
 import { ASSOCIATION_TYPES, CML_DATA_TYPES, CONSTRAINT_TYPES } from '../constants/constants.js';
 import { Association, CmlAttribute, CmlConstraint, CmlModel, CmlType } from '../types/types.js';
+import { convertToCmlExpression, isKnownOperator, operatorRequiresValues } from '../cml-operators.js';
 import {
   ParsedRuleDefinition,
   RuleCondition,
@@ -23,20 +24,6 @@ import {
   RuleRecord,
   UnderwritingRuleGroup,
 } from './models.js';
-
-function operatorToCml(op: string): string {
-  const operators: Record<string, string> = {
-    Equals: '==',
-    NotEquals: '!=',
-    LessThan: '<',
-    LessThanOrEquals: '<=',
-    GreaterThan: '>',
-    GreaterThanOrEquals: '>=',
-    Contains: '.contains',
-    In: '==',
-  };
-  return operators[op] ?? '==';
-}
 
 function dataTypeToCml(dataType?: string): string {
   const types: Record<string, string> = {
@@ -53,6 +40,21 @@ function dataTypeToCml(dataType?: string): string {
 
 export function sanitizeName(name: string): string {
   return name.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+/**
+ * Decodes the common HTML entities that can appear in a RuleDefinition / DynamicRuleDefinition
+ * field when the JSON was persisted HTML-escaped. `&amp;` is decoded last so already-decoded
+ * ampersands are not double-processed.
+ */
+export function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&');
 }
 
 function stripSpaces(stage: string): string {
@@ -77,16 +79,16 @@ export function generateRuleKey(
 }
 
 function buildConditionExpression(condition: RuleCondition): string | null {
-  if (!condition.values || condition.values.length === 0) return null;
+  if (!isKnownOperator(condition.operator)) return null;
+
+  const op = condition.operator;
+  if (operatorRequiresValues(op) && (!condition.values || condition.values.length === 0)) {
+    return null;
+  }
 
   const attrName = sanitizeName(condition.attributeName ?? condition.contextTagName ?? 'unknown');
-  const op = operatorToCml(condition.operator);
-  const value = condition.values[0];
   const cmlDataType = dataTypeToCml(condition.dataType);
-  const isNumeric = cmlDataType === CML_DATA_TYPES.INTEGER || cmlDataType === CML_DATA_TYPES.DECIMAL;
-  const quotedValue = isNumeric ? value : `"${value}"`;
-
-  return `${attrName} ${op} ${quotedValue}`;
+  return convertToCmlExpression(attrName, op, condition.values, cmlDataType);
 }
 
 function buildCriteriaExpression(criteria: RuleCriteria): string | null {

--- a/src/shared/insurance/models.ts
+++ b/src/shared/insurance/models.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export type RuleCondition = {
+  contextTagName?: string;
+  operator: string;
+  conditionIndex?: number;
+  attributeName?: string;
+  attributePicklistValueId?: string;
+  attributeId?: string;
+  dataType?: string;
+  type?: string;
+  values?: string[];
+};
+
+export type RuleCriteria = {
+  rootObjectId: string;
+  criteriaIndex?: number;
+  sourceContextTagName?: string;
+  sourceOperator?: string;
+  sourceDataType?: string;
+  sourceValues?: string[];
+  conditions?: RuleCondition[];
+};
+
+export type UnderwritingRuleGroup = {
+  fromStage?: string;
+  toStage?: string;
+  stageTransitionName?: string;
+};
+
+export type ParsedRuleDefinition = {
+  name: string;
+  apiName: string;
+  productPath: string;
+  status?: string;
+  description?: string;
+  ruleCriteria?: RuleCriteria[];
+  underwritingRuleGroup?: UnderwritingRuleGroup;
+};
+
+export type RuleRecord = {
+  Id: string;
+  Name: string;
+  ProductPath: string;
+};
+
+export type RuleKeyEntry = {
+  recordId: string;
+  name: string;
+  ruleKey: string;
+};

--- a/test/commands/cml/convert/surcharge-rules.nut.ts
+++ b/test/commands/cml/convert/surcharge-rules.nut.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+
+describe('cml convert surcharge-rules NUTs', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('runs against a surcharge JSON file', () => {
+    const command = 'cml convert surcharge-rules --surcharge-file data/surcharges.json --cml-api SC_TEST --target-org myOrg';
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).to.contain('Converted');
+  });
+});
+*/

--- a/test/commands/cml/convert/underwriting-rules.nut.ts
+++ b/test/commands/cml/convert/underwriting-rules.nut.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
+import { expect } from 'chai';
+
+describe('cml convert underwriting-rules NUTs', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+  });
+
+  after(async () => {
+    await session?.clean();
+  });
+
+  it('runs against an underwriting JSON file', () => {
+    const command = 'cml convert underwriting-rules --uw-file data/uw.json --cml-api UW_TEST --target-org myOrg';
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).to.contain('Converted');
+  });
+});
+*/

--- a/test/shared/cml-operators.test.ts
+++ b/test/shared/cml-operators.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import {
+  convertToCmlExpression,
+  escapeQuotes,
+  isKnownOperator,
+  operatorRequiresValues,
+} from '../../src/shared/cml-operators.js';
+import { RuleConditionOperator } from '../../src/shared/models.js';
+
+describe('escapeQuotes', () => {
+  it('escapes single quotes', () => {
+    expect(escapeQuotes("O'Brien")).to.equal("O\\'Brien");
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeQuotes('He said "hi"')).to.equal('He said \\"hi\\"');
+  });
+
+  it('leaves quote-free strings unchanged', () => {
+    expect(escapeQuotes('plain')).to.equal('plain');
+  });
+});
+
+describe('convertToCmlExpression', () => {
+  it('maps comparison operators (including the LessThan < / LessThanOrEquals <= distinction)', () => {
+    const cases: Array<{ operator: RuleConditionOperator; expected: string }> = [
+      { operator: 'Equals', expected: 'X == 5' },
+      { operator: 'NotEquals', expected: 'X != 5' },
+      { operator: 'LessThan', expected: 'X < 5' },
+      { operator: 'LessThanOrEquals', expected: 'X <= 5' },
+      { operator: 'GreaterThan', expected: 'X > 5' },
+      { operator: 'GreaterThanOrEquals', expected: 'X >= 5' },
+    ];
+    for (const { operator, expected } of cases) {
+      expect(convertToCmlExpression('X', operator, ['5'], 'integer')).to.equal(expected);
+    }
+  });
+
+  it('keeps LessThan as < and LessThanOrEquals as <= (regression guard for the prior <= typo)', () => {
+    expect(convertToCmlExpression('Age', 'LessThan', ['60'], 'integer')).to.equal('Age < 60');
+    expect(convertToCmlExpression('Age', 'LessThanOrEquals', ['60'], 'integer')).to.equal('Age <= 60');
+  });
+
+  it('quotes string values for Equals/NotEquals', () => {
+    expect(convertToCmlExpression('Model', 'Equals', ['SUV'], 'string')).to.equal('Model == "SUV"');
+    expect(convertToCmlExpression('Model', 'NotEquals', ['SUV'], 'string')).to.equal('Model != "SUV"');
+  });
+
+  it('Contains emits strcontain(...)', () => {
+    expect(convertToCmlExpression('Description', 'Contains', ['SUV'], 'string')).to.equal(
+      'strcontain(Description, "SUV")'
+    );
+  });
+
+  it('DoesNotContain negates strcontain(...)', () => {
+    expect(convertToCmlExpression('Description', 'DoesNotContain', ['SUV'], 'string')).to.equal(
+      '!strcontain(Description, "SUV")'
+    );
+  });
+
+  it('In expands every value into a parenthesized || chain', () => {
+    expect(convertToCmlExpression('Model', 'In', ['SUV', 'Sedan', 'Truck'], 'string')).to.equal(
+      '(Model == "SUV" || Model == "Sedan" || Model == "Truck")'
+    );
+  });
+
+  it('In with a single value still wraps in parentheses', () => {
+    expect(convertToCmlExpression('Model', 'In', ['SUV'], 'string')).to.equal('(Model == "SUV")');
+  });
+
+  it('NotIn negates the parenthesized || chain', () => {
+    expect(convertToCmlExpression('Model', 'NotIn', ['SUV', 'Sedan'], 'string')).to.equal(
+      '!(Model == "SUV" || Model == "Sedan")'
+    );
+  });
+
+  it('IsNull and IsNotNull need no values', () => {
+    expect(convertToCmlExpression('Model', 'IsNull')).to.equal('Model == null');
+    expect(convertToCmlExpression('Model', 'IsNotNull')).to.equal('Model != null');
+  });
+
+  it('escapes single quotes inside string values', () => {
+    expect(convertToCmlExpression('Name', 'Equals', ["O'Brien"], 'string')).to.equal('Name == "O\\\'Brien"');
+  });
+
+  it('escapes double quotes inside string values', () => {
+    expect(convertToCmlExpression('Greeting', 'Equals', ['He said "hi"'], 'string')).to.equal(
+      'Greeting == "He said \\"hi\\""'
+    );
+  });
+
+  it('throws on an unsupported operator', () => {
+    expect(() => convertToCmlExpression('X', 'Foobar' as RuleConditionOperator, ['1'], 'string')).to.throw(
+      'Unsupported rule operator: Foobar'
+    );
+  });
+});
+
+describe('isKnownOperator', () => {
+  it('returns true for every supported operator', () => {
+    const known = [
+      'Equals',
+      'NotEquals',
+      'LessThan',
+      'LessThanOrEquals',
+      'GreaterThan',
+      'GreaterThanOrEquals',
+      'IsNotNull',
+      'IsNull',
+      'Contains',
+      'DoesNotContain',
+      'In',
+      'NotIn',
+    ];
+    for (const op of known) {
+      expect(isKnownOperator(op), op).to.equal(true);
+    }
+  });
+
+  it('returns false for an unknown operator (guards the skip path)', () => {
+    expect(isKnownOperator('Foobar')).to.equal(false);
+    expect(isKnownOperator('')).to.equal(false);
+  });
+});
+
+describe('operatorRequiresValues', () => {
+  it('returns false for null operators', () => {
+    expect(operatorRequiresValues('IsNull')).to.equal(false);
+    expect(operatorRequiresValues('IsNotNull')).to.equal(false);
+  });
+
+  it('returns true for value-bearing operators', () => {
+    expect(operatorRequiresValues('Equals')).to.equal(true);
+    expect(operatorRequiresValues('In')).to.equal(true);
+    expect(operatorRequiresValues('Contains')).to.equal(true);
+  });
+});

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -25,7 +25,11 @@ import {
   sanitizeName,
 } from '../../../src/shared/insurance/insurance-rule-generator.js';
 import { ParsedRuleDefinition, RuleCriteria, RuleRecord } from '../../../src/shared/insurance/models.js';
-import { discoverCmlApiByProducts, fetchProductCodes } from '../../../src/shared/insurance/insurance-org.js';
+import {
+  discoverCmlApiByProducts,
+  fetchProductCodes,
+  quoteSoqlIdList,
+} from '../../../src/shared/insurance/insurance-org.js';
 
 function mockConnection(queryResults: Record<string, { records: unknown[] }>): Connection {
   return {
@@ -571,13 +575,30 @@ describe('buildCmlModel', () => {
   });
 });
 
+describe('quoteSoqlIdList', () => {
+  it('quotes well-formed Salesforce ids', () => {
+    expect(quoteSoqlIdList(['01tSB000004V4KKYA0', '01tSB000004V4KNYA0'])).to.equal(
+      "'01tSB000004V4KKYA0','01tSB000004V4KNYA0'"
+    );
+  });
+
+  it('drops values that are not valid Salesforce ids (SOQL-injection safe)', () => {
+    const ids = ["01tSB000004V4KKYA0') OR Name != null --", "'; DROP", '01tSB000004V4KNYA0'];
+    expect(quoteSoqlIdList(ids)).to.equal("'01tSB000004V4KNYA0'");
+  });
+
+  it('returns an empty string when no ids are valid', () => {
+    expect(quoteSoqlIdList(["') OR Id != null", 'not-an-id'])).to.equal('');
+  });
+});
+
 describe('discoverCmlApiByProducts', () => {
   it('returns ApiName when existing CML is found', async () => {
     const conn = mockConnection({
-      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: 'es1' }] },
+      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: '0RB000000000001AAA' }] },
       ExpressionSet: { records: [{ ApiName: 'AutoTest' }] },
     });
-    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    const result = await discoverCmlApiByProducts(conn, new Set(['01tSB000004V4KKYA0']));
     expect(result).to.equal('AutoTest');
   });
 
@@ -585,15 +606,15 @@ describe('discoverCmlApiByProducts', () => {
     const conn = mockConnection({
       ExpressionSetConstraintObj: { records: [] },
     });
-    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    const result = await discoverCmlApiByProducts(conn, new Set(['01tSB000004V4KKYA0']));
     expect(result).to.be.undefined;
   });
 
   it('returns undefined when ExpressionSet not found', async () => {
     const conn = mockConnection({
-      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: 'es1' }] },
+      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: '0RB000000000001AAA' }] },
     });
-    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    const result = await discoverCmlApiByProducts(conn, new Set(['01tSB000004V4KKYA0']));
     expect(result).to.be.undefined;
   });
 
@@ -609,22 +630,22 @@ describe('fetchProductCodes', () => {
     const conn = mockConnection({
       Product2: {
         records: [
-          { Id: 'p1', ProductCode: 'autoSilver', Name: 'Auto Silver' },
-          { Id: 'p2', ProductCode: 'health', Name: 'Health Plan' },
+          { Id: '01tSB000004V4KKYA0', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tSB000004V4KNYA0', ProductCode: 'health', Name: 'Health Plan' },
         ],
       },
     });
-    const result = await fetchProductCodes(conn, new Set(['p1', 'p2']));
-    expect(result.get('p1')).to.equal('autoSilver');
-    expect(result.get('p2')).to.equal('health');
+    const result = await fetchProductCodes(conn, new Set(['01tSB000004V4KKYA0', '01tSB000004V4KNYA0']));
+    expect(result.get('01tSB000004V4KKYA0')).to.equal('autoSilver');
+    expect(result.get('01tSB000004V4KNYA0')).to.equal('health');
   });
 
   it('falls back to Name when ProductCode is null', async () => {
     const conn = mockConnection({
-      Product2: { records: [{ Id: 'p1', ProductCode: null, Name: 'FallbackName' }] },
+      Product2: { records: [{ Id: '01tSB000004V4KKYA0', ProductCode: null, Name: 'FallbackName' }] },
     });
-    const result = await fetchProductCodes(conn, new Set(['p1']));
-    expect(result.get('p1')).to.equal('FallbackName');
+    const result = await fetchProductCodes(conn, new Set(['01tSB000004V4KKYA0']));
+    expect(result.get('01tSB000004V4KKYA0')).to.equal('FallbackName');
   });
 
   it('returns empty map for empty product set', async () => {

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -20,6 +20,7 @@ import {
   buildConstraintDeclaration,
   buildStageTransition,
   collectAttributes,
+  decodeHtmlEntities,
   generateRuleKey,
   sanitizeName,
 } from '../../../src/shared/insurance/insurance-rule-generator.js';
@@ -48,6 +49,28 @@ describe('sanitizeName', () => {
 
   it('handles special characters', () => {
     expect(sanitizeName('foo-bar.baz')).to.equal('foo_bar_baz');
+  });
+});
+
+describe('decodeHtmlEntities', () => {
+  it('decodes &quot; into double quotes so JSON parses', () => {
+    const raw = '{&quot;name&quot;:&quot;Auto_Auto&quot;,&quot;ruleCriteria&quot;:null}';
+    const decoded = decodeHtmlEntities(raw);
+    expect(decoded).to.equal('{"name":"Auto_Auto","ruleCriteria":null}');
+    expect((JSON.parse(decoded) as { name: string }).name).to.equal('Auto_Auto');
+  });
+
+  it('decodes &lt; &gt; &#39; and &apos;', () => {
+    expect(decodeHtmlEntities('a &lt; b &gt; c &#39;d&#39; &apos;e&apos;')).to.equal("a < b > c 'd' 'e'");
+  });
+
+  it('decodes &amp; last so it does not double-decode', () => {
+    expect(decodeHtmlEntities('&amp;quot;')).to.equal('&quot;');
+  });
+
+  it('leaves already-decoded JSON unchanged', () => {
+    const raw = '{"name":"Plain","ruleCriteria":[]}';
+    expect(decodeHtmlEntities(raw)).to.equal(raw);
   });
 });
 
@@ -205,6 +228,133 @@ describe('buildConstraintDeclaration', () => {
       };
       expect(buildConstraintDeclaration(ruleDef)).to.equal(`X ${expected} 5`);
     }
+  });
+
+  it('Contains uses strcontain function', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Description', operator: 'Contains', dataType: 'String', values: ['SUV'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('strcontain(Description, "SUV")');
+  });
+
+  it('DoesNotContain negates strcontain', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Description', operator: 'DoesNotContain', dataType: 'String', values: ['SUV'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('!strcontain(Description, "SUV")');
+  });
+
+  it('In with multiple values produces || chain', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Model', operator: 'In', dataType: 'String', values: ['SUV', 'Sedan', 'Truck'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('(Model == "SUV" || Model == "Sedan" || Model == "Truck")');
+  });
+
+  it('In with a single value still wraps in parentheses', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Model', operator: 'In', dataType: 'String', values: ['SUV'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('(Model == "SUV")');
+  });
+
+  it('NotIn with multiple values negates || chain', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Model', operator: 'NotIn', dataType: 'String', values: ['SUV', 'Sedan'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('!(Model == "SUV" || Model == "Sedan")');
+  });
+
+  it('IsNull does not require values', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Model', operator: 'IsNull' }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == null');
+  });
+
+  it('IsNotNull does not require values', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Model', operator: 'IsNotNull' }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model != null');
+  });
+
+  it('escapes single quotes inside string values', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Name', operator: 'Equals', dataType: 'String', values: ["O'Brien"] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Name == "O\\\'Brien"');
+  });
+
+  it('escapes double quotes inside string values', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Greeting', operator: 'Equals', dataType: 'String', values: ['He said "hi"'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Greeting == "He said \\"hi\\""');
+  });
+
+  it('skips conditions with unknown operators', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'X', operator: 'Foobar', dataType: 'String', values: ['1'] },
+            { attributeName: 'Y', operator: 'Equals', dataType: 'String', values: ['1'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Y == "1"');
   });
 });
 

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { Connection } from '@salesforce/core';
+import {
+  buildCmlModel,
+  buildConstraintDeclaration,
+  buildStageTransition,
+  collectAttributes,
+  generateRuleKey,
+  sanitizeName,
+} from '../../../src/shared/insurance/insurance-rule-generator.js';
+import { ParsedRuleDefinition, RuleCriteria, RuleRecord } from '../../../src/shared/insurance/models.js';
+import { discoverCmlApiByProducts, fetchProductCodes } from '../../../src/shared/insurance/insurance-org.js';
+
+function mockConnection(queryResults: Record<string, { records: unknown[] }>): Connection {
+  return {
+    query: (soql: string) => {
+      for (const [key, value] of Object.entries(queryResults)) {
+        if (soql.includes(key)) return Promise.resolve(value);
+      }
+      return Promise.resolve({ records: [] });
+    },
+  } as unknown as Connection;
+}
+
+describe('sanitizeName', () => {
+  it('replaces non-alphanumeric characters with underscores', () => {
+    expect(sanitizeName('Draft to InReview')).to.equal('Draft_to_InReview');
+  });
+
+  it('leaves alphanumeric and underscores unchanged', () => {
+    expect(sanitizeName('AutoSilverRoot')).to.equal('AutoSilverRoot');
+  });
+
+  it('handles special characters', () => {
+    expect(sanitizeName('foo-bar.baz')).to.equal('foo_bar_baz');
+  });
+});
+
+describe('buildStageTransition', () => {
+  it('returns undefined when ruleGroup is undefined', () => {
+    expect(buildStageTransition(undefined)).to.be.undefined;
+  });
+
+  it('returns undefined when fromStage is missing', () => {
+    expect(buildStageTransition({ toStage: 'Approved' })).to.be.undefined;
+  });
+
+  it('returns undefined when toStage is missing', () => {
+    expect(buildStageTransition({ fromStage: 'Draft' })).to.be.undefined;
+  });
+
+  it('builds transition from simple stages', () => {
+    expect(buildStageTransition({ fromStage: 'Draft', toStage: 'Approved' })).to.equal('DraftToApproved');
+  });
+
+  it('strips spaces from stage names', () => {
+    expect(buildStageTransition({ fromStage: 'In Review', toStage: 'Approved' })).to.equal('InReviewToApproved');
+  });
+
+  it('handles Draft To In Review', () => {
+    expect(buildStageTransition({ fromStage: 'Draft', toStage: 'In Review' })).to.equal('DraftToInReview');
+  });
+});
+
+describe('generateRuleKey', () => {
+  it('generates 3-segment key without stage transition (surcharge)', () => {
+    expect(generateRuleKey('SC', 'autoSilver', 'MyRule')).to.equal('SC__autoSilver__MyRule');
+  });
+
+  it('generates 4-segment key with stage transition (underwriting)', () => {
+    expect(generateRuleKey('UW', 'autoSilver', 'AutoSilverRoot', 'DraftToApproved')).to.equal(
+      'UW__autoSilver__DraftToApproved__AutoSilverRoot'
+    );
+  });
+
+  it('sanitizes product code and apiName', () => {
+    expect(generateRuleKey('UW', 'auto Silver', 'My Rule')).to.equal('UW__auto_Silver__My_Rule');
+  });
+});
+
+describe('buildConstraintDeclaration', () => {
+  it('returns true when no ruleCriteria', () => {
+    expect(buildConstraintDeclaration({})).to.equal('true');
+  });
+
+  it('returns true when ruleCriteria is empty', () => {
+    expect(buildConstraintDeclaration({ ruleCriteria: [] })).to.equal('true');
+  });
+
+  it('builds single condition expression', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            {
+              attributeName: 'Model',
+              operator: 'Equals',
+              dataType: 'String',
+              values: ['SUV'],
+            },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SUV"');
+  });
+
+  it('builds numeric condition without quotes', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            {
+              attributeName: 'Year',
+              operator: 'GreaterThan',
+              dataType: 'Number',
+              values: ['2020'],
+            },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Year > 2020');
+  });
+
+  it('joins multiple conditions with &&', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SUV'] },
+            { attributeName: 'Year', operator: 'GreaterThan', dataType: 'Number', values: ['2020'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SUV" && Year > 2020');
+  });
+
+  it('joins multiple criteria with ||', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'A', operator: 'Equals', dataType: 'String', values: ['x'] }],
+        },
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'B', operator: 'Equals', dataType: 'String', values: ['y'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('(A == "x") || (B == "y")');
+  });
+
+  it('ignores product source conditions (removed per meeting decision)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          sourceContextTagName: 'Product',
+          sourceValues: ['01tABC'],
+          conditions: [{ attributeName: 'Age', operator: 'LessThan', dataType: 'Number', values: ['60'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Age < 60');
+  });
+
+  it('maps all operators correctly', () => {
+    const ops = [
+      { operator: 'Equals', expected: '==' },
+      { operator: 'NotEquals', expected: '!=' },
+      { operator: 'LessThan', expected: '<' },
+      { operator: 'LessThanOrEquals', expected: '<=' },
+      { operator: 'GreaterThan', expected: '>' },
+      { operator: 'GreaterThanOrEquals', expected: '>=' },
+    ];
+    for (const { operator, expected } of ops) {
+      const ruleDef = {
+        ruleCriteria: [
+          {
+            rootObjectId: '01t',
+            conditions: [{ attributeName: 'X', operator, dataType: 'Number', values: ['5'] }],
+          },
+        ] as RuleCriteria[],
+      };
+      expect(buildConstraintDeclaration(ruleDef)).to.equal(`X ${expected} 5`);
+    }
+  });
+});
+
+describe('collectAttributes', () => {
+  it('returns empty set when no criteria', () => {
+    const result = collectAttributes([{ ruleDef: {} }]);
+    expect(result.size).to.equal(0);
+  });
+
+  it('collects unique attribute names across rules', () => {
+    const ruleDefs = [
+      {
+        ruleDef: {
+          ruleCriteria: [
+            { rootObjectId: '01t', conditions: [{ attributeName: 'Model', operator: 'Equals', values: ['x'] }] },
+          ],
+        },
+      },
+      {
+        ruleDef: {
+          ruleCriteria: [
+            {
+              rootObjectId: '01t',
+              conditions: [
+                { attributeName: 'Model', operator: 'Equals', values: ['y'] },
+                { attributeName: 'Year', operator: 'Equals', values: ['z'] },
+              ],
+            },
+          ],
+        },
+      },
+    ] as Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>;
+    const result = collectAttributes(ruleDefs);
+    expect(result).to.deep.equal(new Set(['Model', 'Year']));
+  });
+
+  it('uses contextTagName when attributeName is missing', () => {
+    const ruleDefs = [
+      {
+        ruleDef: {
+          ruleCriteria: [
+            { rootObjectId: '01t', conditions: [{ contextTagName: 'TagA', operator: 'Equals', values: ['x'] }] },
+          ],
+        },
+      },
+    ] as Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>;
+    const result = collectAttributes(ruleDefs);
+    expect(result).to.deep.equal(new Set(['TagA']));
+  });
+});
+
+describe('buildCmlModel', () => {
+  const makeRecord = (id: string, name: string, productPath: string): RuleRecord => ({
+    Id: id,
+    Name: name,
+    ProductPath: productPath,
+  });
+
+  const makeRuleDef = (
+    name: string,
+    apiName: string,
+    productPath: string,
+    criteria?: RuleCriteria[],
+    underwritingRuleGroup?: ParsedRuleDefinition['underwritingRuleGroup']
+  ): ParsedRuleDefinition => ({
+    name,
+    apiName,
+    productPath,
+    ruleCriteria: criteria,
+    underwritingRuleGroup,
+  });
+
+  it('creates one type per root product', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', 'p1/child1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1/child1') },
+      { record: makeRecord('r2', 'Rule2', 'p1/child2'), ruleDef: makeRuleDef('Rule2', 'Rule2', 'p1/child2') },
+      { record: makeRecord('r3', 'Rule3', 'p2'), ruleDef: makeRuleDef('Rule3', 'Rule3', 'p2') },
+    ];
+    const productMap = new Map([
+      ['p1', 'ProductA'],
+      ['p2', 'ProductB'],
+    ]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+
+    const types = cmlModel.types;
+    expect(types).to.have.length(2);
+    expect(types.map((t) => t.name).sort()).to.deep.equal(['ProductA', 'ProductB']);
+  });
+
+  it('puts constraints under their product type', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', 'p1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1') },
+      { record: makeRecord('r2', 'Rule2', 'p2'), ruleDef: makeRuleDef('Rule2', 'Rule2', 'p2') },
+    ];
+    const productMap = new Map([
+      ['p1', 'Alpha'],
+      ['p2', 'Beta'],
+    ]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'UW', 'Test');
+
+    const alphaType = cmlModel.getType('Alpha');
+    const betaType = cmlModel.getType('Beta');
+    expect(alphaType?.constraints).to.have.length(1);
+    expect(betaType?.constraints).to.have.length(1);
+    expect(alphaType?.constraints[0].name).to.equal('Rule1');
+    expect(betaType?.constraints[0].name).to.equal('Rule2');
+  });
+
+  it('creates one association per product (not per rule)', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', 'p1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1') },
+      { record: makeRecord('r2', 'Rule2', 'p1'), ruleDef: makeRuleDef('Rule2', 'Rule2', 'p1') },
+    ];
+    const productMap = new Map([['p1', 'ProdX']]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+
+    expect(cmlModel.associations).to.have.length(1);
+    expect(cmlModel.associations[0].tag).to.equal('ProdX');
+    expect(cmlModel.associations[0].referenceObjectId).to.equal('p1');
+  });
+
+  it('generates surcharge ruleKey with 3 segments', () => {
+    const ruleDefs = [{ record: makeRecord('r1', 'MyRule', 'p1'), ruleDef: makeRuleDef('MyRule', 'MyRule', 'p1') }];
+    const productMap = new Map([['p1', 'autoSilver']]);
+    const { ruleKeyMapping } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+
+    expect(ruleKeyMapping).to.have.length(1);
+    expect(ruleKeyMapping[0].ruleKey).to.equal('SC__autoSilver__MyRule');
+  });
+
+  it('generates underwriting ruleKey with 4 segments including stage transition', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'UWRule1', 'p1'),
+        ruleDef: makeRuleDef('UWRule1', 'UWRule1', 'p1', undefined, {
+          fromStage: 'Draft',
+          toStage: 'Approved',
+        }),
+      },
+    ];
+    const productMap = new Map([['p1', 'autoSilver']]);
+    const { ruleKeyMapping } = buildCmlModel(ruleDefs, productMap, 'UW', 'Test');
+
+    expect(ruleKeyMapping).to.have.length(1);
+    expect(ruleKeyMapping[0].ruleKey).to.equal('UW__autoSilver__DraftToApproved__UWRule1');
+  });
+
+  it('scopes attributes per product type', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'Rule1', 'p1'),
+        ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [{ attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SUV'] }],
+          },
+        ]),
+      },
+      {
+        record: makeRecord('r2', 'Rule2', 'p2'),
+        ruleDef: makeRuleDef('Rule2', 'Rule2', 'p2', [
+          {
+            rootObjectId: 'p2',
+            conditions: [
+              { attributeName: 'Deductible', operator: 'GreaterThan', dataType: 'Number', values: ['1000'] },
+            ],
+          },
+        ]),
+      },
+    ];
+    const productMap = new Map([
+      ['p1', 'Auto'],
+      ['p2', 'Health'],
+    ]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'UW', 'Test');
+
+    const autoType = cmlModel.getType('Auto');
+    const healthType = cmlModel.getType('Health');
+    expect(autoType?.attributes.map((a) => a.name)).to.deep.equal(['Model']);
+    expect(healthType?.attributes.map((a) => a.name)).to.deep.equal(['Deductible']);
+  });
+
+  it('falls back to product ID when code is not in map', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', '01tXXX'), ruleDef: makeRuleDef('Rule1', 'Rule1', '01tXXX') },
+    ];
+    const productMap = new Map<string, string>();
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+
+    expect(cmlModel.types[0].name).to.equal('01tXXX');
+    expect(ruleKeyMapping[0].ruleKey).to.equal('SC__01tXXX__Rule1');
+  });
+
+  it('generates CML output with correct type structure', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'Rule1', 'p1'),
+        ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [{ attributeName: 'Age', operator: 'LessThan', dataType: 'Number', values: ['60'] }],
+          },
+        ]),
+      },
+    ];
+    const productMap = new Map([['p1', 'autoSilver']]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'UW', 'Test');
+
+    const cml = cmlModel.generateCml();
+    expect(cml).to.include('type autoSilver');
+    expect(cml).to.include('constraint Rule1');
+    expect(cml).to.include('Age < 60');
+    expect(cml).to.not.include('type LineItem');
+  });
+});
+
+describe('discoverCmlApiByProducts', () => {
+  it('returns ApiName when existing CML is found', async () => {
+    const conn = mockConnection({
+      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: 'es1' }] },
+      ExpressionSet: { records: [{ ApiName: 'AutoTest' }] },
+    });
+    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    expect(result).to.equal('AutoTest');
+  });
+
+  it('returns undefined when no associations exist', async () => {
+    const conn = mockConnection({
+      ExpressionSetConstraintObj: { records: [] },
+    });
+    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined when ExpressionSet not found', async () => {
+    const conn = mockConnection({
+      ExpressionSetConstraintObj: { records: [{ ExpressionSetId: 'es1' }] },
+    });
+    const result = await discoverCmlApiByProducts(conn, new Set(['p1']));
+    expect(result).to.be.undefined;
+  });
+
+  it('returns undefined for empty product set', async () => {
+    const conn = mockConnection({});
+    const result = await discoverCmlApiByProducts(conn, new Set());
+    expect(result).to.be.undefined;
+  });
+});
+
+describe('fetchProductCodes', () => {
+  it('returns map of product ID to ProductCode', async () => {
+    const conn = mockConnection({
+      Product2: {
+        records: [
+          { Id: 'p1', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: 'p2', ProductCode: 'health', Name: 'Health Plan' },
+        ],
+      },
+    });
+    const result = await fetchProductCodes(conn, new Set(['p1', 'p2']));
+    expect(result.get('p1')).to.equal('autoSilver');
+    expect(result.get('p2')).to.equal('health');
+  });
+
+  it('falls back to Name when ProductCode is null', async () => {
+    const conn = mockConnection({
+      Product2: { records: [{ Id: 'p1', ProductCode: null, Name: 'FallbackName' }] },
+    });
+    const result = await fetchProductCodes(conn, new Set(['p1']));
+    expect(result.get('p1')).to.equal('FallbackName');
+  });
+
+  it('returns empty map for empty product set', async () => {
+    const conn = mockConnection({});
+    const result = await fetchProductCodes(conn, new Set());
+    expect(result.size).to.equal(0);
+  });
+});

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -212,139 +212,9 @@ describe('buildConstraintDeclaration', () => {
     expect(buildConstraintDeclaration(ruleDef)).to.equal('Age < 60');
   });
 
-  it('maps all operators correctly', () => {
-    const ops = [
-      { operator: 'Equals', expected: '==' },
-      { operator: 'NotEquals', expected: '!=' },
-      { operator: 'LessThan', expected: '<' },
-      { operator: 'LessThanOrEquals', expected: '<=' },
-      { operator: 'GreaterThan', expected: '>' },
-      { operator: 'GreaterThanOrEquals', expected: '>=' },
-    ];
-    for (const { operator, expected } of ops) {
-      const ruleDef = {
-        ruleCriteria: [
-          {
-            rootObjectId: '01t',
-            conditions: [{ attributeName: 'X', operator, dataType: 'Number', values: ['5'] }],
-          },
-        ] as RuleCriteria[],
-      };
-      expect(buildConstraintDeclaration(ruleDef)).to.equal(`X ${expected} 5`);
-    }
-  });
-
-  it('Contains uses strcontain function', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Description', operator: 'Contains', dataType: 'String', values: ['SUV'] }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('strcontain(Description, "SUV")');
-  });
-
-  it('DoesNotContain negates strcontain', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [
-            { attributeName: 'Description', operator: 'DoesNotContain', dataType: 'String', values: ['SUV'] },
-          ],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('!strcontain(Description, "SUV")');
-  });
-
-  it('In with multiple values produces || chain', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [
-            { attributeName: 'Model', operator: 'In', dataType: 'String', values: ['SUV', 'Sedan', 'Truck'] },
-          ],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('(Model == "SUV" || Model == "Sedan" || Model == "Truck")');
-  });
-
-  it('In with a single value still wraps in parentheses', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Model', operator: 'In', dataType: 'String', values: ['SUV'] }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('(Model == "SUV")');
-  });
-
-  it('NotIn with multiple values negates || chain', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Model', operator: 'NotIn', dataType: 'String', values: ['SUV', 'Sedan'] }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('!(Model == "SUV" || Model == "Sedan")');
-  });
-
-  it('IsNull does not require values', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Model', operator: 'IsNull' }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == null');
-  });
-
-  it('IsNotNull does not require values', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Model', operator: 'IsNotNull' }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model != null');
-  });
-
-  it('escapes single quotes inside string values', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Name', operator: 'Equals', dataType: 'String', values: ["O'Brien"] }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('Name == "O\\\'Brien"');
-  });
-
-  it('escapes double quotes inside string values', () => {
-    const ruleDef = {
-      ruleCriteria: [
-        {
-          rootObjectId: '01t',
-          conditions: [{ attributeName: 'Greeting', operator: 'Equals', dataType: 'String', values: ['He said "hi"'] }],
-        },
-      ] as RuleCriteria[],
-    };
-    expect(buildConstraintDeclaration(ruleDef)).to.equal('Greeting == "He said \\"hi\\""');
-  });
+  // Operator-level semantics (mapping, strcontain, In/NotIn chains, null operators, quote
+  // escaping, unknown-operator handling) are locked in test/shared/cml-operators.test.ts so
+  // the shared module keeps its own coverage independent of this generator.
 
   it('skips conditions with unknown operators', () => {
     const ruleDef = {
@@ -504,6 +374,23 @@ describe('buildCmlModel', () => {
 
     expect(ruleKeyMapping).to.have.length(1);
     expect(ruleKeyMapping[0].ruleKey).to.equal('UW__autoSilver__DraftToApproved__UWRule1');
+  });
+
+  it('avoids constraint-name collisions when two rules share apiName under the same product', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'A', 'p1'),
+        ruleDef: makeRuleDef('A', 'SharedApi', 'p1', undefined, { fromStage: 'Draft', toStage: 'InReview' }),
+      },
+      {
+        record: makeRecord('r2', 'B', 'p1'),
+        ruleDef: makeRuleDef('B', 'SharedApi', 'p1', undefined, { fromStage: 'InReview', toStage: 'Approved' }),
+      },
+    ];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'UW', 'Test');
+    const names = cmlModel.getType('autoSilver')!.constraints.map((c) => c.name);
+    expect(names).to.deep.equal(['SharedApi_DraftToInReview', 'SharedApi_InReviewToApproved']);
+    expect(new Set(names).size).to.equal(2);
   });
 
   it('scopes attributes per product type', () => {


### PR DESCRIPTION
Work Item: @W-22787786@

## Summary

Adds two new commands and a parallel `src/shared/insurance/` submodule that ports the insurance BRE→CML rule converters onto this plugin's module shape. Reuses the plugin's existing CML types, utils, and constants.

- `sf cml convert surcharge-rules` — converts `ProductSurcharge` records (or a JSON file) into a CML eligibility constraint model.
- `sf cml convert underwriting-rules` — converts `UnderwritingRule` records (or a JSON file) into a CML eligibility constraint model.

Each command writes `<api>.cml`, `<api>_Associations.csv`, and `<api>_RuleKeyMapping.json`, and accepts `--update-records` to write `RuleEngineType=ConstraintEngine` back to the org.

## Design

- Shared operator handling lives in `src/shared/cml-operators.ts` and is reused by both `bre-rules-generator.ts` and the insurance generator (single correct implementation of `Contains`/`In`/`NotIn`/null operators + quote-escaping).
- The two commands share an abstract `InsuranceRuleConvertCommand` base class to avoid duplication.
- User-facing strings live in message bundles (`messages/cml.convert.surcharge-rules.md`, `messages/cml.convert.underwriting-rules.md`).

## Notable robustness handling

- Underwriting SOQL filters on `RuleKey = null` only (`DynamicRuleDefinition` is non-filterable); records without a definition are skipped during parsing.
- HTML-entity-encoded rule definitions (`&quot;`) are decoded before `JSON.parse`, so BRE rules stored HTML-escaped are converted instead of silently skipped.
- Per-rule try/catch: one bad rule warns and is skipped instead of aborting the run.

## Test plan

- [ ] `yarn install && yarn test` — unit tests pass (operator mappings, HTML decode, ruleKey shape, constraint assembly, model construction, org helpers).
- [ ] `sf cml convert surcharge-rules --help` and `sf cml convert underwriting-rules --help` verify command registration + message bundles.
- [ ] Run surcharge command in fixture mode to verify non-trivial constraint expressions without org dependency.
- [ ] (Optional) Run each command against a sandbox with insurance data, including `--update-records`.

Made with [Cursor](https://cursor.com)
