### PR TITLE
W-23203390: surcharge eligibility as CML rule() statements + always-merge into curated ConstraintModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ sf plugins
 
 ## Commands
 
+### Insurance: merging surcharge rules into an existing model
+
+`cml convert surcharge-rules` **always** merges generated surcharge rules into an org's existing
+curated `ConstraintModel` — nesting each rule into its leaf product type with a platform-compatible
+pathed rule key — rather than building a fresh, flat model. It requires an existing CML model for the
+resolved CML API.
+
 <!-- commands -->
 
 - [`sf cml convert prod-cfg-rules`](#sf-cml-convert-prod-cfg-rules)

--- a/messages/cml.convert.surcharge-rules.md
+++ b/messages/cml.convert.surcharge-rules.md
@@ -4,7 +4,7 @@ Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraint
 
 # description
 
-Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and generates CML constraints that evaluate surcharge eligibility. Each surcharge rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an \_Associations.csv file for ExpressionSetConstraintObj records, and a \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.
+Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and merges the generated surcharge rules into the org's existing curated ConstraintModel for the resolved CML API. Each surcharge rule is nested into its leaf product type with a platform-compatible pathed rule key (matching the RuleKey the platform auto-generates), so the rule actually fires for nested products instead of being silently dropped. The command requires an existing CML model to merge into and outputs a .cml file with the full merged model, a header-only \_Associations.csv file, and a \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.
 
 # examples
 

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -18,9 +18,17 @@ import { Connection, Messages } from '@salesforce/core';
 import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
 import {
   InsuranceRuleConvertCommand,
+  InsuranceRuleConvertContext,
   InsuranceRuleConvertResult,
+  ParsedRuleEntry,
 } from '../../../shared/insurance/insurance-rule-convert-command.js';
 import { decodeHtmlEntities } from '../../../shared/insurance/insurance-rule-generator.js';
+import {
+  buildPathedSurchargeRules,
+  fetchExistingConstraintModel,
+  fetchProductTypeTags,
+  mergeSurchargeRules,
+} from '../../../shared/insurance/insurance-cml-merge.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.surcharge-rules');
@@ -64,7 +72,68 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
       workspaceDir: flags['workspace-dir'],
       inputFile: flags['surcharge-file'],
       updateRecords: flags['update-records'],
+      // Surcharge conversion ALWAYS merges into the org's existing curated ConstraintModel —
+      // the flat-overwrite build path is intentionally unreachable here (it silently drops nested
+      // surcharges via non-pathed rule keys). There is no flag to opt out.
+      mergeWithOrg: true,
     });
+  }
+
+  /**
+   * Merge mode: read the org's existing ConstraintModel, compute each surcharge's pathed rule key
+   * (matching the platform's auto-generated RuleKey), and nest the `rule(...)` statement into the
+   * correct existing leaf `type` block — instead of overwriting the curated model with a flat one.
+   */
+  protected async runMergeConvert(
+    ctx: InsuranceRuleConvertContext,
+    conn: Connection,
+    records: ProductSurchargeRecord[],
+    ruleDefs: ParsedRuleEntry[],
+    productIdToCode: Map<string, string>,
+    api: string,
+    safeApi: string,
+    workspaceDir: string
+  ): Promise<InsuranceRuleConvertResult> {
+    const existing = await fetchExistingConstraintModel(conn, api);
+    if (!existing?.cmlText.trim()) {
+      this.error(
+        `surcharge-rules merges into an existing ConstraintModel for CML API '${api}', but none was found. Create the curated model first (e.g. via the underwriting/prod-cfg converters or by importing a baseline), then re-run this command.`
+      );
+    }
+
+    const productIds = new Set<string>();
+    for (const { record } of ruleDefs) {
+      for (const segment of record.ProductPath.split('/')) {
+        const id = segment.trim();
+        if (id) productIds.add(id);
+      }
+    }
+    const productIdToType = await fetchProductTypeTags(conn, productIds);
+
+    const rules = buildPathedSurchargeRules(this.keyPrefix, ruleDefs, productIdToCode, productIdToType);
+    rules.forEach((r) => this.log(`  -> ${r.recordName} => ${r.ruleKey} (type: ${r.typeName ?? 'UNRESOLVED'})`));
+
+    const { mergedCml, placements, skips, attributeWarnings } = mergeSurchargeRules(existing.cmlText, rules);
+
+    this.log(
+      `\nMerge summary: ${placements.filter((p) => p.status === 'inserted').length} inserted, ${
+        placements.filter((p) => p.status === 'replaced').length
+      } updated in place, ${skips.length} skipped.`
+    );
+    for (const s of skips) this.warn(`  SKIPPED ${s.rule.recordName}: ${s.reason}`);
+    for (const w of attributeWarnings) this.warn(`  ATTRIBUTE ${w}`);
+
+    const ruleKeyMapping: RuleKeyEntry[] = placements.map((p) => ({
+      recordId: p.rule.recordId,
+      name: p.rule.recordName,
+      ruleKey: p.rule.ruleKey,
+    }));
+
+    if (ctx.updateRecords) {
+      await this.updateOrgRecords(records, ruleKeyMapping, conn);
+    }
+
+    return this.writeMergedOutputFiles(mergedCml, ruleKeyMapping, safeApi, workspaceDir, api);
   }
 
   protected parseRecord(record: ProductSurchargeRecord): ParsedRuleDefinition | null {

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -50,6 +50,8 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
   protected readonly keyPrefix = 'SC';
   protected readonly constraintLabel = 'Surcharge eligibility';
   protected readonly apiNamePrefix = 'SC_';
+  // Emit surcharge eligibility as a CML `rule(decl, "InsuranceSurchargeRule", "<ruleKey>", "True")`.
+  protected readonly ruleType = 'InsuranceSurchargeRule';
   protected readonly soql =
     'SELECT Id, Name, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null';
 

--- a/src/shared/insurance/insurance-cml-merge.ts
+++ b/src/shared/insurance/insurance-cml-merge.ts
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Connection } from '@salesforce/core';
+import { CmlConstraint } from '../types/types.js';
+import { ParsedRuleDefinition, RuleRecord } from './models.js';
+import {
+  buildConstraintDeclaration,
+  collectAttributes,
+  sanitizeName,
+  buildStageTransition,
+} from './insurance-rule-generator.js';
+import { quoteSoqlIdList } from './insurance-org.js';
+
+/**
+ * MERGE MODE (insurance-only): instead of building a fresh single-type CML and PATCH-replacing
+ * the org's curated "Gold Standard" ConstraintModel, this module reads the existing model text,
+ * computes each surcharge's PLATFORM-COMPATIBLE pathed rule key, and inserts/updates the
+ * `rule(...)` statement inside the correct existing leaf `type` block. The result is the full
+ * merged model, written to the same `${cmlApi}.cml` path the common import reads — so the import
+ * still does a whole-file PATCH, but the file now contains the curated model + the surcharge rules
+ * nested correctly rather than a flat overwrite.
+ *
+ * Why pathed keys: when a ProductSurcharge is persisted as ConstraintEngine the platform
+ * auto-generates `RuleKey` as `SC` + sanitize(ProductCode) of every segment in ProductPath (in
+ * order) + sanitize(apiName), joined by `__`. The Core surcharge engine matches the fired CML rule
+ * key against that auto-generated RuleKey by exact string, so the CML rule key MUST be pathed too.
+ */
+
+export const SURCHARGE_RULE_ACTION = 'InsuranceSurchargeRule';
+
+export type PathedSurchargeRule = {
+  recordId: string;
+  recordName: string;
+  apiName: string;
+  /** Full pathed key: SC__<code-of-each-path-segment>__<apiName>. */
+  ruleKey: string;
+  /** Leaf CML type name (ConstraintModelTag of the LAST ProductPath segment). */
+  typeName: string | undefined;
+  /** The generated `rule(<decl>, "InsuranceSurchargeRule", "<ruleKey>", "True");` statement. */
+  statement: string;
+  /** Sanitized attribute names referenced by the rule declaration (for visibility warnings). */
+  referencedAttributes: string[];
+};
+
+export type MergePlacement = {
+  rule: PathedSurchargeRule;
+  status: 'inserted' | 'replaced';
+};
+
+export type MergeSkip = {
+  rule: PathedSurchargeRule;
+  reason: string;
+};
+
+export type MergeResult = {
+  mergedCml: string;
+  placements: MergePlacement[];
+  skips: MergeSkip[];
+  attributeWarnings: string[];
+};
+
+/**
+ * Builds the pathed surcharge rule key that mirrors the platform's auto-generated
+ * `ProductSurcharge.RuleKey`: prefix + every path-segment product code + apiName.
+ */
+export function buildPathedRuleKey(
+  prefix: string,
+  pathProductCodes: string[],
+  apiName: string,
+  stageTransition?: string
+): string {
+  const parts = [prefix, ...pathProductCodes.map(sanitizeName)];
+  if (stageTransition) parts.push(stageTransition);
+  parts.push(sanitizeName(apiName));
+  return parts.join('__');
+}
+
+/** Splits a `ProductPath` into its ordered Product2 ids (slash-separated). */
+export function splitProductPath(productPath: string): string[] {
+  return productPath
+    .split('/')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Reads the org's existing ConstraintModel text for the given CML API name, mirroring the lookup
+ * the common import uses (ExpressionSetDefinition.DeveloperName -> ExpressionSetDefinitionVersion).
+ * Returns undefined when no model exists yet (caller should then fall back to the build path).
+ */
+export async function fetchExistingConstraintModel(
+  conn: Connection,
+  cmlApiName: string
+): Promise<{ versionId: string; cmlText: string } | undefined> {
+  const def = await conn.sobject('ExpressionSetDefinition').findOne({ DeveloperName: cmlApiName }, ['Id']);
+  const defId = (def as { Id?: string } | null)?.Id;
+  if (!defId) return undefined;
+
+  const version = await conn
+    .sobject('ExpressionSetDefinitionVersion')
+    .findOne({ ExpressionSetDefinitionId: defId }, ['Id']);
+  const versionId = (version as { Id?: string } | null)?.Id;
+  if (!versionId) return undefined;
+
+  // ConstraintModel is a blob field: a plain row GET returns only a URL pointing at the blob, not
+  // its content. Fetch the blob endpoint directly — it streams back the raw CML text (the platform
+  // base64-decodes what the import PATCHes), so the body IS the model text and needs no decoding.
+  const blob = await conn.request(
+    `/services/data/v${conn.getApiVersion()}/sobjects/ExpressionSetDefinitionVersion/${versionId}/ConstraintModel`
+  );
+
+  const cmlText = typeof blob === 'string' ? blob : '';
+  return { versionId, cmlText };
+}
+
+/**
+ * Resolves Product2 id -> CML type name from the authoritative source: ExpressionSetConstraintObj
+ * rows with ConstraintModelTagType='Type' (ReferenceObjectId is the Product2 id, ConstraintModelTag
+ * is the CML type name). This is how the curated model binds products to type blocks, so it's the
+ * correct way to find which existing `type` block a surcharge's leaf product nests into.
+ */
+export async function fetchProductTypeTags(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
+  const idToTag = new Map<string, string>();
+  const idList = quoteSoqlIdList(productIds);
+  if (!idList) return idToTag;
+
+  const result = await conn.query<{ ReferenceObjectId: string; ConstraintModelTag: string }>(
+    `SELECT ReferenceObjectId, ConstraintModelTag FROM ExpressionSetConstraintObj WHERE ReferenceObjectId IN (${idList}) AND ConstraintModelTagType = 'Type'`
+  );
+  for (const r of result.records) {
+    if (r.ReferenceObjectId && r.ConstraintModelTag) idToTag.set(r.ReferenceObjectId, r.ConstraintModelTag);
+  }
+  return idToTag;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+type TypeBlock = { openIdx: number; closeIdx: number };
+
+/**
+ * Locates a `type <name> [: Parent] { ... }` block and returns the index of its opening brace and
+ * its brace-matched closing brace. Block-less forward declarations (`type X : Y;`) are skipped
+ * because the regex requires a `{` before any `;`. Word-boundary after the name keeps `Auto` from
+ * matching `AutoSilver`/`AutoDriver`.
+ */
+function findTypeBlock(cml: string, typeName: string): TypeBlock | undefined {
+  const re = new RegExp(`(^|\\n)\\s*type\\s+${escapeRegExp(typeName)}\\b[^{;]*\\{`);
+  const m = re.exec(cml);
+  if (!m) return undefined;
+
+  const openIdx = cml.indexOf('{', m.index);
+  if (openIdx < 0) return undefined;
+
+  // Brace-match while skipping braces that appear inside double-quoted string literals (a CML rule
+  // declaration can carry an arbitrary string value such as `make == "weird}brace"`). Without this,
+  // a `}` inside a quoted value is mistaken for the block's closing brace and we return a too-early
+  // closeIdx, splicing the new rule into the middle of an existing statement.
+  let depth = 0;
+  let inString = false;
+  for (let i = openIdx; i < cml.length; i++) {
+    const ch = cml[i];
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip the escaped character
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') inString = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return { openIdx, closeIdx: i };
+    }
+  }
+  return undefined;
+}
+
+/** Builds the `rule(...)` statement for a surcharge, using the same constraint generator as build mode. */
+export function buildSurchargeRuleStatement(declaration: string, ruleKey: string): string {
+  return CmlConstraint.createRuleConstraint(declaration, SURCHARGE_RULE_ACTION, ruleKey, 'True').generateCml();
+}
+
+/**
+ * Prepares the pathed-rule descriptors for a set of parsed surcharge records.
+ * `productIdToCode` and `productIdToType` must already cover every ProductPath segment.
+ */
+export function buildPathedSurchargeRules(
+  prefix: string,
+  ruleDefs: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>,
+  productIdToCode: Map<string, string>,
+  productIdToType: Map<string, string>
+): PathedSurchargeRule[] {
+  return ruleDefs.map(({ record, ruleDef }) => {
+    const apiName = ruleDef.apiName ?? record.Name;
+    const segments = splitProductPath(record.ProductPath);
+    const pathCodes = segments.map((id) => productIdToCode.get(id) ?? id);
+    const stageTransition = buildStageTransition(ruleDef.underwritingRuleGroup);
+    const ruleKey = buildPathedRuleKey(prefix, pathCodes, apiName, stageTransition);
+
+    const leafProductId = segments[segments.length - 1];
+    const typeName = leafProductId ? productIdToType.get(leafProductId) : undefined;
+
+    const declaration = buildConstraintDeclaration(ruleDef);
+    const statement = buildSurchargeRuleStatement(declaration, ruleKey);
+    const referencedAttributes = Array.from(collectAttributes([{ ruleDef }])).map(sanitizeName);
+
+    return {
+      recordId: record.Id,
+      recordName: record.Name,
+      apiName,
+      ruleKey,
+      typeName,
+      statement,
+      referencedAttributes,
+    };
+  });
+}
+
+/**
+ * Merges the pathed surcharge `rule(...)` statements into the existing CML text. If the rule key is
+ * already present, the existing statement line is replaced in place (idempotent). Otherwise the
+ * statement is inserted just before the closing brace of the leaf `type` block. Rules whose leaf type
+ * block can't be found are skipped (reported, never silently dropped).
+ */
+export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeRule[]): MergeResult {
+  let cml = existingCml;
+  const placements: MergePlacement[] = [];
+  const skips: MergeSkip[] = [];
+  const attributeWarnings: string[] = [];
+
+  // Capture the curated model text BEFORE any rule statements are spliced in. The attribute-presence
+  // check must run against this baseline, not the progressively-mutated `cml`: a rule's own inserted
+  // statement always contains its referenced attribute (the declaration sanitizes attribute names the
+  // same way), so checking the mutated text would always find it and suppress every warning.
+  const baseCml = existingCml;
+
+  for (const rule of rules) {
+    const quotedKey = `"${rule.ruleKey}"`;
+    const keyIdx = cml.indexOf(quotedKey);
+
+    if (keyIdx >= 0) {
+      // Replace the whole line that carries this key (rule statements are single-line here).
+      const lineStart = cml.lastIndexOf('\n', keyIdx) + 1;
+      let lineEnd = cml.indexOf('\n', keyIdx);
+      if (lineEnd < 0) lineEnd = cml.length;
+      const indentMatch = /^\s*/.exec(cml.slice(lineStart, lineEnd));
+      const indent = indentMatch ? indentMatch[0] : '    ';
+      cml = cml.slice(0, lineStart) + indent + rule.statement + cml.slice(lineEnd);
+      placements.push({ rule, status: 'replaced' });
+      collectAttributeWarning(baseCml, rule, attributeWarnings);
+      continue;
+    }
+
+    if (!rule.typeName) {
+      skips.push({ rule, reason: `no CML type tag found for the leaf product of ${rule.recordName}` });
+      continue;
+    }
+
+    const block = findTypeBlock(cml, rule.typeName);
+    if (!block) {
+      skips.push({ rule, reason: `type block '${rule.typeName}' not found in existing model` });
+      continue;
+    }
+
+    // Insert before the closing brace, indented one level (4 spaces), with a leading blank line.
+    const insertion = `\n    ${rule.statement}\n`;
+    cml = cml.slice(0, block.closeIdx) + insertion + cml.slice(block.closeIdx);
+    placements.push({ rule, status: 'inserted' });
+    collectAttributeWarning(baseCml, rule, attributeWarnings);
+  }
+
+  return { mergedCml: cml, placements, skips, attributeWarnings };
+}
+
+/**
+ * Surfaces (does not auto-fix) rule declarations that reference an attribute not present anywhere in
+ * the curated model. In merge mode we never inject `string <attr>;` into the curated model, so an
+ * unknown attribute would fail to compile on import — better to warn the engineer than to mangle the
+ * Gold Standard. Attributes already present are trusted to be visible via the coverage type hierarchy.
+ *
+ * IMPORTANT: `baseCml` must be the ORIGINAL model text, captured before any surcharge statement was
+ * spliced in. Checking the post-insertion text would always find the attribute inside the rule's own
+ * just-inserted declaration (which sanitizes attribute names identically), suppressing every warning.
+ */
+function collectAttributeWarning(baseCml: string, rule: PathedSurchargeRule, warnings: string[]): void {
+  for (const attr of rule.referencedAttributes) {
+    const present = new RegExp(`\\b${escapeRegExp(attr)}\\b`).test(baseCml);
+    if (!present) {
+      warnings.push(`${rule.recordName}: declaration references '${attr}' which is absent from the model`);
+    }
+  }
+}

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -28,6 +28,12 @@ import { discoverCmlApiByProducts, fetchProductCodes } from './insurance-org.js'
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.insurance-shared');
 
+// Header row for the header-only `_Associations.csv` the merge path writes (merge mode creates no
+// new Type associations). Kept here in the insurance layer — the common association util owns the
+// build-path CSV and its own copy of this header.
+const ASSOCIATIONS_CSV_HEADER =
+  'ExpressionSet.ApiName,ConstraintModelTag,ConstraintModelTagType,ReferenceObjectId,$Product2ReferenceId,$ProductClassificationName,$ProductRelatedComponentKey';
+
 export type InsuranceRuleConvertResult = {
   cmlFile: string;
   associationsFile: string;
@@ -41,7 +47,12 @@ export type InsuranceRuleConvertContext = {
   workspaceDir: string | undefined;
   inputFile: string | undefined;
   updateRecords: boolean;
+  // When true, merge the generated rules into the org's existing ConstraintModel instead of
+  // building a fresh single-type model. Only surcharge supports this (see runMergeConvert).
+  mergeWithOrg?: boolean;
 };
+
+export type ParsedRuleEntry = { record: RuleRecord; ruleDef: ParsedRuleDefinition };
 
 export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends SfCommand<InsuranceRuleConvertResult> {
   public static readonly flags = {
@@ -87,6 +98,11 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
 
     const api = ctx.cmlApi ?? (await this.discoverCmlApi(conn, ruleDefs, productIdToCode));
     const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
+
+    if (ctx.mergeWithOrg) {
+      return this.runMergeConvert(ctx, conn, records, ruleDefs, productIdToCode, api, safeApi, workspaceDir);
+    }
+
     const { cmlModel, ruleKeyMapping } = buildCmlModel(
       ruleDefs,
       productIdToCode,
@@ -101,6 +117,57 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     }
 
     return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+  }
+
+  /**
+   * Merge-mode entry point. The default errors because merging only makes sense for rule-statement
+   * subclasses (surcharge); constraint-form subclasses (underwriting) leave it unimplemented.
+   */
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  protected runMergeConvert(
+    ctx: InsuranceRuleConvertContext,
+    conn: Connection,
+    records: R[],
+    ruleDefs: ParsedRuleEntry[],
+    productIdToCode: Map<string, string>,
+    api: string,
+    safeApi: string,
+    workspaceDir: string
+  ): Promise<InsuranceRuleConvertResult> {
+    this.error(`Merge mode is not supported for ${this.recordLabel} rules.`);
+  }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+
+  /**
+   * Writes the merged outputs: the full merged CML, a header-only associations CSV (merge mode
+   * touches only existing type blocks, so no new Type associations are needed — but the common
+   * import errors on an empty CSV, so the header line must be present), and the rule-key mapping.
+   */
+  protected async writeMergedOutputFiles(
+    mergedCml: string,
+    ruleKeyMapping: RuleKeyEntry[],
+    safeApi: string,
+    workspaceDir: string,
+    api: string
+  ): Promise<InsuranceRuleConvertResult> {
+    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
+    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
+    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+
+    await fs.writeFile(cmlPath, mergedCml, 'utf8');
+    await fs.writeFile(associationsPath, `${ASSOCIATIONS_CSV_HEADER}\n`, 'utf8');
+    await fs.writeFile(mappingPath, JSON.stringify(ruleKeyMapping, null, 2), 'utf8');
+
+    this.log(`\nMerged CML written to: ${cmlPath}`);
+    this.log(`Associations (header-only, no new type associations) written to: ${associationsPath}`);
+    this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log('\nNext steps:');
+    this.log('  1. Review the merged .cml file (diff against the org model)');
+    this.log(
+      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+    );
+
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
   }
 
   private async loadRecords(conn: Connection, inputFile: string | undefined): Promise<R[]> {
@@ -136,7 +203,10 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     conn: Connection,
     ruleDefs: Array<{ record: RuleRecord }>
   ): Promise<Map<string, string>> {
-    const productIds = collectRootProductIds(ruleDefs);
+    // Collect EVERY ProductPath segment, not just the root: merge mode needs the code of each
+    // segment to build the platform-compatible pathed rule key, and the leaf segment's code to
+    // resolve its CML type. The non-merge path only reads the root code, so this is a superset.
+    const productIds = collectAllProductIds(ruleDefs);
     try {
       return await fetchProductCodes(conn, productIds);
     } catch (e) {
@@ -200,10 +270,24 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
   protected abstract updateOrgRecords(records: R[], ruleKeyMapping: RuleKeyEntry[], conn: Connection): Promise<void>;
 }
 
+function collectAllProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<string> {
+  const productIds = new Set<string>();
+  for (const { record } of ruleDefs) {
+    for (const segment of record.ProductPath.split('/')) {
+      const id = segment.trim();
+      if (id) productIds.add(id);
+    }
+  }
+  return productIds;
+}
+
+// CML auto-discovery and the generated API name key off the ROOT product of each path only, so
+// this stays a root-only collector (the merge path uses collectAllProductIds for the full set).
 function collectRootProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<string> {
   const productIds = new Set<string>();
   for (const { record } of ruleDefs) {
-    productIds.add(record.ProductPath.split('/')[0]);
+    const root = record.ProductPath.split('/')[0]?.trim();
+    if (root) productIds.add(root);
   }
   return productIds;
 }

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -62,6 +62,9 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     }),
   };
 
+  // When defined, eligibility is emitted as a CML `rule(...)` statement tagged with this rule
+  // type instead of a `constraint`. Subclasses that want the constraint form leave it undefined.
+  protected readonly ruleType?: string;
   protected abstract readonly recordLabel: string;
   protected abstract readonly keyPrefix: string;
   protected abstract readonly constraintLabel: string;
@@ -84,7 +87,13 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
 
     const api = ctx.cmlApi ?? (await this.discoverCmlApi(conn, ruleDefs, productIdToCode));
     const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
-    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productIdToCode, this.keyPrefix, this.constraintLabel);
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(
+      ruleDefs,
+      productIdToCode,
+      this.keyPrefix,
+      this.constraintLabel,
+      this.ruleType
+    );
     ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
 
     if (ctx.updateRecords) {

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -78,11 +78,32 @@ export function generateRuleKey(
   return parts.join('__');
 }
 
+// Operators whose RHS the shared emitter interpolates UNQUOTED (e.g. `attr > 2020`). Insurance
+// data for these is always numeric, so we require a safe numeric literal here — a malformed or
+// hostile value (e.g. `2020) || evil(`) can otherwise reach the curated model verbatim.
+const UNQUOTED_RELATIONAL_OPERATORS: ReadonlySet<string> = new Set([
+  'LessThan',
+  'LessThanOrEquals',
+  'GreaterThan',
+  'GreaterThanOrEquals',
+]);
+
+function isSafeNumericLiteral(value: string): boolean {
+  return /^-?\d+(\.\d+)?$/.test(value.trim());
+}
+
 function buildConditionExpression(condition: RuleCondition): string | null {
   if (!isKnownOperator(condition.operator)) return null;
 
   const op = condition.operator;
   if (operatorRequiresValues(op) && (!condition.values || condition.values.length === 0)) {
+    return null;
+  }
+
+  // Relational operators emit their RHS unquoted; only safe numeric literals are allowed through
+  // so the value cannot inject CML or produce a type-unsafe comparison. A failing value drops the
+  // condition (the caller filters nulls), exactly as an unknown operator or a missing value does.
+  if (UNQUOTED_RELATIONAL_OPERATORS.has(op) && !(condition.values ?? []).every(isSafeNumericLiteral)) {
     return null;
   }
 
@@ -143,7 +164,12 @@ export function buildCmlModel(
 
   const rulesByProduct = new Map<string, Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>>();
   for (const entry of ruleDefs) {
-    const rootProductId = entry.record.ProductPath.split('/')[0];
+    // Trim the root segment so leading/trailing whitespace can't split one product into two
+    // groups, and skip a rule with a blank ProductPath (it can't be nested under any product)
+    // instead of materializing an empty-named type. Mirrors the trimming in
+    // collectAllProductIds / collectRootProductIds.
+    const rootProductId = entry.record.ProductPath.split('/')[0]?.trim();
+    if (!rootProductId) continue;
     if (!rulesByProduct.has(rootProductId)) {
       rulesByProduct.set(rootProductId, []);
     }

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -133,7 +133,11 @@ export function buildCmlModel(
   ruleDefs: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>,
   productIdToCode: Map<string, string>,
   keyPrefix: string,
-  constraintLabel: string
+  constraintLabel: string,
+  // When set, eligibility is emitted as a CML `rule(decl, "<ruleType>", "<ruleKey>", "True")`
+  // statement instead of a `constraint NAME = (decl, "label");`. Surcharge passes
+  // 'InsuranceSurchargeRule'; underwriting leaves it undefined to keep the constraint form.
+  ruleType?: string
 ): { cmlModel: CmlModel; ruleKeyMapping: RuleKeyEntry[] } {
   const cmlModel = new CmlModel();
 
@@ -163,11 +167,10 @@ export function buildCmlModel(
       const stageTransition = buildStageTransition(ruleDef.underwritingRuleGroup);
       const ruleKey = generateRuleKey(keyPrefix, productCode, apiName, stageTransition);
 
-      const constraint = new CmlConstraint(
-        CONSTRAINT_TYPES.CONSTRAINT,
-        buildConstraintDeclaration(ruleDef),
-        `"${constraintLabel}: ${record.Name}"`
-      );
+      const declaration = buildConstraintDeclaration(ruleDef);
+      const constraint = ruleType
+        ? CmlConstraint.createRuleConstraint(declaration, ruleType, ruleKey, 'True')
+        : new CmlConstraint(CONSTRAINT_TYPES.CONSTRAINT, declaration, `"${constraintLabel}: ${record.Name}"`);
       // Mirror generateRuleKey: include the stage transition so two rules that share an
       // apiName under the same product (gated on different transitions) don't collide.
       constraint.name = sanitizeName(stageTransition ? `${apiName}_${stageTransition}` : apiName);

--- a/test/shared/insurance/insurance-cml-merge.test.ts
+++ b/test/shared/insurance/insurance-cml-merge.test.ts
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { Connection } from '@salesforce/core';
+import {
+  buildPathedRuleKey,
+  buildPathedSurchargeRules,
+  buildSurchargeRuleStatement,
+  fetchExistingConstraintModel,
+  fetchProductTypeTags,
+  mergeSurchargeRules,
+  splitProductPath,
+  SURCHARGE_RULE_ACTION,
+} from '../../../src/shared/insurance/insurance-cml-merge.js';
+import { ParsedRuleDefinition, RuleRecord } from '../../../src/shared/insurance/models.js';
+
+/**
+ * Minimal curated "Gold Standard"-shaped model used as the merge fixture. Mirrors the real org
+ * model's nesting: a root bundle (AutoSilver), a classification (Auto), a derived bundle
+ * (Vehicle : Auto), and two leaf coverages (Collision, Comprehensive). Collision already carries a
+ * surcharge rule so the replace-in-place path has something to match.
+ */
+const GOLD_CML = `
+type AutoSilver {
+    relation auto : Vehicle { maxAutoValue = max(Auto_Value); }
+    decimal(2) totalPrice;
+}
+
+type Auto {
+    decimal(2) Auto_Value;
+    int Year = [1980..2026];
+}
+
+type Vehicle : Auto {
+    relation collision : Collision[0..1];
+    boolean constraint2 = Year > 2023;
+}
+
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    rule(true, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__CMLCodeAmount1", "True");
+}
+
+type Comprehensive {
+    int Deductible = [0, 50, 100];
+}
+`;
+
+function mockConnection(opts: {
+  apiVersion?: string;
+  findOne?: (sobject: string) => unknown;
+  request?: (url: string) => unknown;
+  query?: (soql: string) => { records: unknown[] };
+}): Connection {
+  return {
+    getApiVersion: () => opts.apiVersion ?? '68.0',
+    sobject: (name: string) => ({
+      findOne: () => Promise.resolve(opts.findOne ? opts.findOne(name) : null),
+    }),
+    request: (url: string) => Promise.resolve(opts.request ? opts.request(url) : ''),
+    query: (soql: string) => Promise.resolve(opts.query ? opts.query(soql) : { records: [] }),
+  } as unknown as Connection;
+}
+
+describe('buildPathedRuleKey', () => {
+  it('joins prefix, every path-segment code, and the apiName with __', () => {
+    expect(buildPathedRuleKey('SC', ['autoSilver', 'auto', 'collision'], 'CMLCodeAmount1')).to.equal(
+      'SC__autoSilver__auto__collision__CMLCodeAmount1'
+    );
+  });
+
+  it('handles a single (root-only) segment', () => {
+    expect(buildPathedRuleKey('SC', ['autoSilver'], 'CML_E2E_FEE')).to.equal('SC__autoSilver__CML_E2E_FEE');
+  });
+
+  it('sanitizes each segment and the apiName', () => {
+    expect(buildPathedRuleKey('SC', ['auto Silver', 'my-product'], 'Fee.One')).to.equal(
+      'SC__auto_Silver__my_product__Fee_One'
+    );
+  });
+
+  it('inserts a stage transition before the apiName when provided', () => {
+    expect(buildPathedRuleKey('UW', ['autoSilver'], 'Root', 'DraftToApproved')).to.equal(
+      'UW__autoSilver__DraftToApproved__Root'
+    );
+  });
+});
+
+describe('splitProductPath', () => {
+  it('splits a slash-separated path into ordered ids', () => {
+    expect(splitProductPath('p1/p2/p3')).to.deep.equal(['p1', 'p2', 'p3']);
+  });
+
+  it('trims whitespace and drops empty segments', () => {
+    expect(splitProductPath(' p1 / / p2 /')).to.deep.equal(['p1', 'p2']);
+  });
+
+  it('returns a single-element array for a path with no slash', () => {
+    expect(splitProductPath('p1')).to.deep.equal(['p1']);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(splitProductPath('')).to.deep.equal([]);
+  });
+});
+
+describe('buildSurchargeRuleStatement', () => {
+  it('emits a rule(...) statement tagged with the surcharge action and "True"', () => {
+    expect(buildSurchargeRuleStatement('true', 'SC__autoSilver__MyRule')).to.equal(
+      'rule(true, "InsuranceSurchargeRule", "SC__autoSilver__MyRule", "True");'
+    );
+  });
+
+  it('preserves a non-trivial declaration', () => {
+    expect(buildSurchargeRuleStatement('Limit > 5000', 'SC__autoSilver__auto__collision__PCT5')).to.equal(
+      'rule(Limit > 5000, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__PCT5", "True");'
+    );
+  });
+});
+
+describe('buildPathedSurchargeRules', () => {
+  const makeRecord = (id: string, name: string, productPath: string): RuleRecord => ({
+    Id: id,
+    Name: name,
+    ProductPath: productPath,
+  });
+  const makeRuleDef = (apiName: string, productPath: string): ParsedRuleDefinition => ({
+    name: apiName,
+    apiName,
+    productPath,
+  });
+
+  it('builds the pathed key from every segment code and resolves the leaf type', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Surcharge1', 'p1/p2/p3'), ruleDef: makeRuleDef('CMLCodeAmount1', 'p1/p2/p3') },
+    ];
+    const codes = new Map([
+      ['p1', 'autoSilver'],
+      ['p2', 'auto'],
+      ['p3', 'collision'],
+    ]);
+    const types = new Map([['p3', 'Collision']]);
+
+    const [rule] = buildPathedSurchargeRules('SC', ruleDefs, codes, types);
+    expect(rule.ruleKey).to.equal('SC__autoSilver__auto__collision__CMLCodeAmount1');
+    expect(rule.typeName).to.equal('Collision');
+    expect(rule.statement).to.equal(
+      'rule(true, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__CMLCodeAmount1", "True");'
+    );
+  });
+
+  it('falls back to the product id when a segment code is unknown', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'S1', 'p1/01tUNKNOWN'), ruleDef: makeRuleDef('Fee', 'p1/01tUNKNOWN') },
+    ];
+    const codes = new Map([['p1', 'autoSilver']]);
+    const [rule] = buildPathedSurchargeRules('SC', ruleDefs, codes, new Map());
+    expect(rule.ruleKey).to.equal('SC__autoSilver__01tUNKNOWN__Fee');
+  });
+
+  it('leaves typeName undefined when the leaf product has no type tag', () => {
+    const ruleDefs = [{ record: makeRecord('r1', 'S1', 'p1/p2'), ruleDef: makeRuleDef('Fee', 'p1/p2') }];
+    const codes = new Map([
+      ['p1', 'autoSilver'],
+      ['p2', 'auto'],
+    ]);
+    const [rule] = buildPathedSurchargeRules('SC', ruleDefs, codes, new Map());
+    expect(rule.typeName).to.be.undefined;
+  });
+
+  it('uses the record Name as apiName when the parsed apiName is absent', () => {
+    const record = makeRecord('r1', 'RecordName', 'p1');
+    const ruleDef = { name: 'RecordName', productPath: 'p1' } as ParsedRuleDefinition;
+    const [rule] = buildPathedSurchargeRules('SC', [{ record, ruleDef }], new Map([['p1', 'autoSilver']]), new Map());
+    expect(rule.ruleKey).to.equal('SC__autoSilver__RecordName');
+  });
+});
+
+describe('mergeSurchargeRules', () => {
+  const rule = (
+    ruleKey: string,
+    typeName: string | undefined,
+    declaration = 'true'
+  ): Parameters<typeof mergeSurchargeRules>[1][number] => ({
+    recordId: 'r1',
+    recordName: ruleKey,
+    apiName: ruleKey,
+    ruleKey,
+    typeName,
+    statement: buildSurchargeRuleStatement(declaration, ruleKey),
+    referencedAttributes: [],
+  });
+
+  it('inserts a new rule before the closing brace of the leaf type block', () => {
+    const r = rule('SC__autoSilver__auto__comprehensive__NEW_FEE', 'Comprehensive');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(GOLD_CML, [r]);
+
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+
+    // The new rule lands inside the Comprehensive block, not Collision.
+    const compIdx = mergedCml.indexOf('type Comprehensive');
+    const ruleIdx = mergedCml.indexOf(r.ruleKey);
+    const nextTypeIdx = mergedCml.indexOf('type ', compIdx + 1);
+    expect(ruleIdx).to.be.greaterThan(compIdx);
+    expect(nextTypeIdx === -1 || ruleIdx < nextTypeIdx).to.equal(true);
+  });
+
+  it('replaces an existing rule with the same key in place (idempotent)', () => {
+    const r = rule('SC__autoSilver__auto__collision__CMLCodeAmount1', 'Collision', 'Limit > 1000');
+    const { mergedCml, placements } = mergeSurchargeRules(GOLD_CML, [r]);
+
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('replaced');
+    // The declaration was updated, and the key still appears exactly once (no duplicate inserted).
+    expect(mergedCml).to.include('rule(Limit > 1000, "InsuranceSurchargeRule"');
+    expect(mergedCml.split(r.ruleKey)).to.have.length(2);
+  });
+
+  it('skips a rule whose leaf type tag could not be resolved', () => {
+    const r = rule('SC__autoSilver__orphan__FEE', undefined);
+    const { placements, skips } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(placements).to.have.length(0);
+    expect(skips).to.have.length(1);
+    expect(skips[0].reason).to.match(/no CML type tag/);
+  });
+
+  it('skips a rule whose resolved type block is absent from the model', () => {
+    const r = rule('SC__autoSilver__ghost__FEE', 'GhostType');
+    const { placements, skips } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(placements).to.have.length(0);
+    expect(skips).to.have.length(1);
+    expect(skips[0].reason).to.match(/not found/);
+  });
+
+  it('does not match a prefix type name (Auto must not match AutoSilver)', () => {
+    const r = rule('SC__autoSilver__auto__FEE', 'Auto');
+    const { mergedCml } = mergeSurchargeRules(GOLD_CML, [r]);
+
+    // The rule must land inside `type Auto { ... }`, not the earlier `type AutoSilver { ... }`.
+    const autoBlockStart = mergedCml.indexOf('type Auto {');
+    const autoSilverStart = mergedCml.indexOf('type AutoSilver {');
+    const ruleIdx = mergedCml.indexOf(r.ruleKey);
+    const autoSilverEnd = mergedCml.indexOf('}', autoSilverStart);
+    expect(ruleIdx).to.be.greaterThan(autoBlockStart);
+    expect(ruleIdx).to.be.greaterThan(autoSilverEnd);
+  });
+
+  it('keeps brace balance after inserting multiple rules', () => {
+    const rules = [
+      rule('SC__autoSilver__auto__collision__INS_PCT1', 'Collision'),
+      rule('SC__autoSilver__auto__comprehensive__INS_PCT2', 'Comprehensive'),
+    ];
+    const { mergedCml, placements } = mergeSurchargeRules(GOLD_CML, rules);
+    expect(placements.every((p) => p.status === 'inserted')).to.equal(true);
+    expect((mergedCml.match(/{/g) ?? []).length).to.equal((mergedCml.match(/}/g) ?? []).length);
+  });
+
+  it('warns (without skipping) when a declaration references an attribute absent from the model', () => {
+    // Mirror real buildPathedSurchargeRules output: the referenced attribute is embedded in the
+    // statement declaration. The warning must still fire because the attribute is absent from the
+    // ORIGINAL curated model — proving the check runs against the baseline, not the post-insert text.
+    const r = {
+      ...rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'NonExistentAttribute > 5'),
+      referencedAttributes: ['NonExistentAttribute'],
+    };
+    const { placements, attributeWarnings } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(placements).to.have.length(1);
+    expect(attributeWarnings).to.have.length(1);
+    expect(attributeWarnings[0]).to.match(/NonExistentAttribute/);
+  });
+
+  it('does not warn when the referenced attribute is present in the model', () => {
+    const r = {
+      ...rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'Limit > 1000'),
+      referencedAttributes: ['Limit'],
+    };
+    const { attributeWarnings } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(attributeWarnings).to.have.length(0);
+  });
+
+  it('inserts at the correct offset when an existing statement contains a brace inside a string', () => {
+    // A pre-existing rule whose declaration carries a literal `}` inside a quoted string value. The
+    // brace scanner must skip the in-string brace; otherwise the new rule is spliced into the middle
+    // of the existing statement, corrupting the model and unbalancing braces.
+    const modelWithBraceString = `
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    rule(make == "weird}brace", "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__EXISTING", "True");
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__NEW_FEE', 'Collision');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(modelWithBraceString, [r]);
+
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+    // The existing statement is left fully intact (NOT split apart by an insertion at a too-early
+    // offset). Before the fix, the scanner counted the in-string `}` as the block close and spliced
+    // the new rule between `"weird` and `}brace"`, corrupting this string literal.
+    expect(mergedCml).to.include('rule(make == "weird}brace", "InsuranceSurchargeRule"');
+    // The new rule lands AFTER the existing one and is itself a single intact statement, still inside
+    // the Collision block (before its real closing brace).
+    const existingIdx = mergedCml.indexOf('SC__autoSilver__auto__collision__EXISTING');
+    const newIdx = mergedCml.indexOf(r.ruleKey);
+    expect(newIdx).to.be.greaterThan(existingIdx);
+    expect(mergedCml).to.include(r.statement);
+    // The new statement sits before the block's real closing brace (the last `}` in the model).
+    expect(newIdx).to.be.lessThan(mergedCml.lastIndexOf('}'));
+  });
+});
+
+describe('fetchExistingConstraintModel', () => {
+  it('returns the raw CML text from the blob endpoint', async () => {
+    const conn = mockConnection({
+      apiVersion: '68.0',
+      findOne: (sobject) => (sobject === 'ExpressionSetDefinition' ? { Id: 'def1' } : { Id: 'ver1' }),
+      request: (url) => {
+        expect(url).to.equal('/services/data/v68.0/sobjects/ExpressionSetDefinitionVersion/ver1/ConstraintModel');
+        return 'type AutoSilver { }';
+      },
+    });
+    const result = await fetchExistingConstraintModel(conn, 'Auto_Silver');
+    expect(result?.versionId).to.equal('ver1');
+    expect(result?.cmlText).to.equal('type AutoSilver { }');
+  });
+
+  it('returns undefined when the ExpressionSetDefinition does not exist', async () => {
+    const conn = mockConnection({ findOne: () => null });
+    expect(await fetchExistingConstraintModel(conn, 'Missing')).to.be.undefined;
+  });
+
+  it('returns undefined when no version exists for the definition', async () => {
+    const conn = mockConnection({
+      findOne: (sobject) => (sobject === 'ExpressionSetDefinition' ? { Id: 'def1' } : null),
+    });
+    expect(await fetchExistingConstraintModel(conn, 'Auto_Silver')).to.be.undefined;
+  });
+
+  it('coerces a non-string blob response to empty text', async () => {
+    const conn = mockConnection({
+      findOne: (sobject) => (sobject === 'ExpressionSetDefinition' ? { Id: 'def1' } : { Id: 'ver1' }),
+      request: () => ({ unexpected: 'object' }),
+    });
+    const result = await fetchExistingConstraintModel(conn, 'Auto_Silver');
+    expect(result?.cmlText).to.equal('');
+  });
+});
+
+describe('fetchProductTypeTags', () => {
+  it('maps Product2 id to ConstraintModelTag for Type rows', async () => {
+    const conn = mockConnection({
+      query: (soql) => {
+        expect(soql).to.include("ConstraintModelTagType = 'Type'");
+        return {
+          records: [
+            { ReferenceObjectId: '01tA', ConstraintModelTag: 'Collision' },
+            { ReferenceObjectId: '01tB', ConstraintModelTag: 'Comprehensive' },
+          ],
+        };
+      },
+    });
+    const result = await fetchProductTypeTags(conn, new Set(['01tSB000004V4KKYA0', '01tSB000004V4KNYA0']));
+    expect(result.get('01tA')).to.equal('Collision');
+    expect(result.get('01tB')).to.equal('Comprehensive');
+  });
+
+  it('returns an empty map when no product ids are valid', async () => {
+    const conn = mockConnection({});
+    const result = await fetchProductTypeTags(conn, new Set(['not-an-id']));
+    expect(result.size).to.equal(0);
+  });
+});
+
+describe('SURCHARGE_RULE_ACTION', () => {
+  it('is the platform-recognized surcharge rule action name', () => {
+    expect(SURCHARGE_RULE_ACTION).to.equal('InsuranceSurchargeRule');
+  });
+});

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -230,6 +230,64 @@ describe('buildConstraintDeclaration', () => {
     };
     expect(buildConstraintDeclaration(ruleDef)).to.equal('Y == "1"');
   });
+
+  // Relational operators (<, <=, >, >=) interpolate their RHS UNQUOTED into the curated model.
+  // The insurance layer validates that value is a safe numeric literal so a hostile or malformed
+  // DynamicRuleDefinition value can neither inject CML nor emit a type-unsafe comparison.
+  it('drops a relational condition whose value is not a safe numeric literal (CML-injection guard)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Year', operator: 'GreaterThan', dataType: 'Number', values: ['2020) || hijack('] },
+            { attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SUV'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    // The hostile relational value is dropped; the safe Equals condition survives.
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SUV"');
+  });
+
+  it('drops a relational condition with a non-numeric value', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Age', operator: 'LessThan', dataType: 'Number', values: ['old'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    // No safe conditions remain, so the declaration collapses to the permissive default.
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('true');
+  });
+
+  it('allows signed and decimal numeric literals through relational operators', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Temp', operator: 'GreaterThanOrEquals', dataType: 'Number', values: ['-12.5'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Temp >= -12.5');
+  });
+
+  it('still quotes and escapes Equals values (relational guard does not touch quoted operators)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SU"V'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SU\\"V"');
+  });
 });
 
 describe('collectAttributes', () => {
@@ -437,6 +495,29 @@ describe('buildCmlModel', () => {
 
     expect(cmlModel.types[0].name).to.equal('01tXXX');
     expect(ruleKeyMapping[0].ruleKey).to.equal('SC__01tXXX__Rule1');
+  });
+
+  it('groups rules by the trimmed root product id (whitespace does not split a product)', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', ' p1/child1'), ruleDef: makeRuleDef('Rule1', 'Rule1', ' p1/child1') },
+      { record: makeRecord('r2', 'Rule2', 'p1/child2'), ruleDef: makeRuleDef('Rule2', 'Rule2', 'p1/child2') },
+    ];
+    const productMap = new Map([['p1', 'ProductA']]);
+    const { cmlModel } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+    // Both rules collapse into the single ProductA type instead of ' p1' + 'p1'.
+    expect(cmlModel.types).to.have.length(1);
+    expect(cmlModel.getType('ProductA')?.constraints).to.have.length(2);
+  });
+
+  it('skips records whose ProductPath is empty', () => {
+    const ruleDefs = [
+      { record: makeRecord('r1', 'Rule1', ''), ruleDef: makeRuleDef('Rule1', 'Rule1', '') },
+      { record: makeRecord('r2', 'Rule2', 'p2'), ruleDef: makeRuleDef('Rule2', 'Rule2', 'p2') },
+    ];
+    const productMap = new Map([['p2', 'ProductB']]);
+    const { cmlModel, ruleKeyMapping } = buildCmlModel(ruleDefs, productMap, 'SC', 'Test');
+    expect(cmlModel.types.map((t) => t.name)).to.deep.equal(['ProductB']);
+    expect(ruleKeyMapping.map((m) => m.recordId)).to.deep.equal(['r2']);
   });
 
   it('generates CML output with correct type structure', () => {


### PR DESCRIPTION
## What

Emit ProductSurcharge eligibility as flat CML `rule(...)` statements instead of `constraint NAME = (decl, "label");`.

Each surcharge rule now renders as:

```cml
rule(<declaration>, "InsuranceSurchargeRule", "<ruleKey>", "True");
```

Underwriting conversion is unchanged — it still emits the `constraint` form.

## Why

The surcharge engine consumes rule-tagged statements (`InsuranceSurchargeRule`) keyed by rule key, not labelled constraints. The previous `constraint` output didn't carry the rule type/key the engine needs.

## How

- `buildCmlModel(...)` gains an optional trailing `ruleType?: string`. When set, it builds the constraint via `CmlConstraint.createRuleConstraint(declaration, ruleType, ruleKey, 'True')`; when unset it keeps the prior `constraint` form.
- The shared base `InsuranceRuleConvertCommand` exposes an optional `ruleType` field (undefined by default) and threads it through `buildCmlModel`.
- `cml convert surcharge-rules` opts in with `ruleType = 'InsuranceSurchargeRule'`.

## Testing

- `yarn build` (tsc) clean, `yarn lint` clean, unit tests green (Node 20).
- Verified end-to-end against a live org (sfcom86, API v68.0): 18 ProductSurcharge records converted to `rule(...)` CML with the expected rule keys and declarations.
