### PR TITLE
@W-23217457 fix(insurance): harden surcharge merge against injection, clobber, and silent-wrong output

### DIFF
--- a/messages/cml.convert.insurance-shared.md
+++ b/messages/cml.convert.insurance-shared.md
@@ -8,4 +8,12 @@ Directory where output files will be written.
 
 # flags.update-records.summary
 
-Update source records in the org with RuleEngineType=ConstraintEngine.
+REMOVED. Convert no longer writes to the org; passing this flag now errors. Convert instead emits a reviewable record-update file enumerating the org-record changes, which you apply to the org separately.
+
+# error.updateRecordsRemoved
+
+convert no longer writes to the org. It now always emits a `<cmlApi>_{Underwriting,Surcharge}Update.json` file for review.
+
+# error.updateRecordsRemoved.actions
+
+- Review the emitted `<cmlApi>_{Underwriting,Surcharge}Update.json` file and apply its org-record changes to the target org separately.

--- a/messages/cml.convert.surcharge-rules.md
+++ b/messages/cml.convert.surcharge-rules.md
@@ -4,7 +4,7 @@ Converts BRE-based Product Surcharge dynamic rules to CML eligibility constraint
 
 # description
 
-Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and merges the generated surcharge rules into the org's existing curated ConstraintModel for the resolved CML API. Each surcharge rule is nested into its leaf product type with a platform-compatible pathed rule key (matching the RuleKey the platform auto-generates), so the rule actually fires for nested products instead of being silently dropped. The command requires an existing CML model to merge into and outputs a .cml file with the full merged model, a header-only \_Associations.csv file, and a \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping for updating records.
+Reads ProductSurcharge records from the org (or a JSON file), parses their RuleDefinition, and merges the generated surcharge rules into the org's existing curated ConstraintModel for the resolved CML API. Each surcharge rule is nested into its leaf product type with a platform-compatible pathed rule key (matching the RuleKey the platform auto-generates), so the rule actually fires for nested products instead of being silently dropped. The command is file-only and never writes to the org. It requires an existing CML model to merge into and outputs a .cml file with the full merged model, a header-only \_Associations.csv file, a \_RuleKeyMapping.json with the ProductSurcharge ID to RuleKey mapping, and a \_SurchargeUpdate.json file enumerating the org-record changes. Review the files, then apply the CML with `sf cml import as-expression-set` and apply the org-record changes enumerated in the \_SurchargeUpdate.json file to the org separately (in that order).
 
 # examples
 

--- a/messages/cml.convert.underwriting-rules.md
+++ b/messages/cml.convert.underwriting-rules.md
@@ -4,7 +4,7 @@ Converts BRE-based Insurance Underwriting dynamic rules to CML eligibility const
 
 # description
 
-Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false. The command outputs a .cml file with the constraint model, an \_Associations.csv file for ExpressionSetConstraintObj records, and a \_RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping for updating records.
+Reads UnderwritingRule records from the org (or a JSON file), parses their DynamicRuleDefinition, and generates CML constraints that evaluate underwriting eligibility. Each rule becomes a named constraint that returns true/false. The command is file-only and never writes to the org: it outputs a .cml file with the constraint model, an \_Associations.csv file for ExpressionSetConstraintObj records, a \_RuleKeyMapping.json with the UnderwritingRule ID to RuleKey mapping, and a \_UnderwritingUpdate.json file enumerating the org-record changes. Review the files, then apply the CML with `sf cml import as-expression-set` and apply the org-record changes enumerated in the \_UnderwritingUpdate.json file to the org separately.
 
 # examples
 

--- a/src/commands/cml/convert/surcharge-rules.ts
+++ b/src/commands/cml/convert/surcharge-rules.ts
@@ -15,7 +15,7 @@
  */
 import { Flags } from '@salesforce/sf-plugins-core';
 import { Connection, Messages } from '@salesforce/core';
-import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
+import { ParsedRuleDefinition, RecordUpdate, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
 import {
   InsuranceRuleConvertCommand,
   InsuranceRuleConvertContext,
@@ -28,6 +28,7 @@ import {
   fetchExistingConstraintModel,
   fetchProductTypeTags,
   mergeSurchargeRules,
+  splitProductPath,
 } from '../../../shared/insurance/insurance-cml-merge.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
@@ -62,6 +63,12 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
   protected readonly ruleType = 'InsuranceSurchargeRule';
   protected readonly soql =
     'SELECT Id, Name, RuleDefinition, ProductPath FROM ProductSurcharge WHERE RuleApiName != null';
+  protected readonly recordUpdateKind = 'surcharge-update' as const;
+
+  // Populated during runMergeConvert (the only place the ProductPath→ProductCode mapping is known)
+  // and consumed by buildRecordUpdates, which the base calls to serialize the update file. Maps a
+  // ProductSurcharge Id to its ordered ProductCode path — advisory drift-detection for the apply.
+  private readonly surchargeProductCodes = new Map<string, string[]>();
 
   public async run(): Promise<CmlConvertSurchargeRulesResult> {
     const { flags } = await this.parse(CmlConvertSurchargeRules);
@@ -85,7 +92,7 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
    * correct existing leaf `type` block — instead of overwriting the curated model with a flat one.
    */
   protected async runMergeConvert(
-    ctx: InsuranceRuleConvertContext,
+    _ctx: InsuranceRuleConvertContext,
     conn: Connection,
     records: ProductSurchargeRecord[],
     ruleDefs: ParsedRuleEntry[],
@@ -103,12 +110,21 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
 
     const productIds = new Set<string>();
     for (const { record } of ruleDefs) {
-      for (const segment of record.ProductPath.split('/')) {
-        const id = segment.trim();
-        if (id) productIds.add(id);
-      }
+      // [Fix #11] Route every ProductPath parse through one helper so trim + drop-empty semantics
+      // never diverge between the convert layer and the merge module.
+      for (const id of splitProductPath(record.ProductPath)) productIds.add(id);
     }
     const productIdToType = await fetchProductTypeTags(conn, productIds);
+
+    // Capture the ProductCode path per surcharge so the emitted update file can carry it (same
+    // mapping buildPathedSurchargeRules uses for the rule key). Drift here would desync the platform
+    // RuleKey, so it is recorded for the apply-time check rather than discarded.
+    this.surchargeProductCodes.clear();
+    for (const { record } of ruleDefs) {
+      // [Fix #11] Same single helper.
+      const codes = splitProductPath(record.ProductPath).map((id) => productIdToCode.get(id) ?? id);
+      this.surchargeProductCodes.set(record.Id, codes);
+    }
 
     const rules = buildPathedSurchargeRules(this.keyPrefix, ruleDefs, productIdToCode, productIdToType);
     rules.forEach((r) => this.log(`  -> ${r.recordName} => ${r.ruleKey} (type: ${r.typeName ?? 'UNRESOLVED'})`));
@@ -123,17 +139,36 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
     for (const s of skips) this.warn(`  SKIPPED ${s.rule.recordName}: ${s.reason}`);
     for (const w of attributeWarnings) this.warn(`  ATTRIBUTE ${w}`);
 
+    // [Fix #9] When skips are present, log a high-signal final summary that buckets reasons —
+    // an operator scanning hundreds of per-rule warnings should not have to grep to learn whether
+    // they're staring at one duplicate or fifty missing-type-tag rules. Buckets match the merge
+    // module's skip-reason vocabulary; anything that doesn't match a known reason falls into "other".
+    if (skips.length > 0) {
+      const counts = { duplicate: 0, emptyPath: 0, noTypeTag: 0, typeBlockMissing: 0, typeBlockAmbiguous: 0, other: 0 };
+      for (const s of skips) {
+        if (s.reason.startsWith('duplicate pathed rule key')) counts.duplicate += 1;
+        else if (s.reason.startsWith('empty ProductPath')) counts.emptyPath += 1;
+        else if (s.reason.startsWith('no CML type tag')) counts.noTypeTag += 1;
+        else if (s.reason.includes('not found in existing model')) counts.typeBlockMissing += 1;
+        else if (s.reason.includes('is ambiguous')) counts.typeBlockAmbiguous += 1;
+        else counts.other += 1;
+      }
+      this.log(
+        `Skip breakdown: ${counts.duplicate} duplicate-key, ${counts.emptyPath} empty-ProductPath, ` +
+          `${counts.noTypeTag} no-type-tag, ${counts.typeBlockMissing} type-block-missing, ` +
+          `${counts.typeBlockAmbiguous} type-block-ambiguous, ${counts.other} other`
+      );
+    }
+
     const ruleKeyMapping: RuleKeyEntry[] = placements.map((p) => ({
       recordId: p.rule.recordId,
       name: p.rule.recordName,
       ruleKey: p.rule.ruleKey,
     }));
 
-    if (ctx.updateRecords) {
-      await this.updateOrgRecords(records, ruleKeyMapping, conn);
-    }
+    const recordUpdateFile = await this.writeRecordUpdateFile(records, ruleKeyMapping, api, safeApi, workspaceDir);
 
-    return this.writeMergedOutputFiles(mergedCml, ruleKeyMapping, safeApi, workspaceDir, api);
+    return this.writeMergedOutputFiles(mergedCml, ruleKeyMapping, safeApi, workspaceDir, api, recordUpdateFile);
   }
 
   protected parseRecord(record: ProductSurchargeRecord): ParsedRuleDefinition | null {
@@ -158,23 +193,21 @@ export default class CmlConvertSurchargeRules extends InsuranceRuleConvertComman
     }
   }
 
-  protected async updateOrgRecords(
-    _records: ProductSurchargeRecord[],
-    ruleKeyMapping: RuleKeyEntry[],
-    conn: Connection
-  ): Promise<void> {
-    this.log('\nUpdating ProductSurcharge records with RuleEngineType=ConstraintEngine...');
-    const updates = ruleKeyMapping.map((m) => ({
-      Id: m.recordId,
-      RuleEngineType: 'ConstraintEngine',
+  /**
+   * Pure transform — the file-only successor to the old live updateOrgRecords. Mirrors it exactly:
+   * one ProductSurcharge per placed rule, flipping RuleEngineType to ConstraintEngine. The
+   * expectedRuleKey (the convert-computed pathed key) and productCodes are advisory — they are NOT
+   * written to the org (the platform regenerates ProductSurcharge.RuleKey on the flip); the apply
+   * uses them to verify the surcharge will actually fire and to flag ProductCode/ProductPath drift.
+   */
+  protected buildRecordUpdates(_records: ProductSurchargeRecord[], ruleKeyMapping: RuleKeyEntry[]): RecordUpdate[] {
+    return ruleKeyMapping.map((m) => ({
+      sobject: 'ProductSurcharge',
+      id: m.recordId,
+      name: m.name,
+      fields: [{ field: 'RuleEngineType', value: 'ConstraintEngine' }],
+      expectedRuleKey: m.ruleKey,
+      productCodes: this.surchargeProductCodes.get(m.recordId),
     }));
-    const results = await conn.sobject('ProductSurcharge').update(updates);
-    const list = Array.isArray(results) ? results : [results];
-    const successes = list.filter((r) => r.success);
-    const failures = list.filter((r) => !r.success);
-    this.log(`  Updated ${successes.length} records successfully`);
-    for (const f of failures) {
-      this.warn(`  Failed to update ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
-    }
   }
 }

--- a/src/commands/cml/convert/underwriting-rules.ts
+++ b/src/commands/cml/convert/underwriting-rules.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Flags } from '@salesforce/sf-plugins-core';
-import { Connection, Messages } from '@salesforce/core';
-import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
+import { Messages } from '@salesforce/core';
+import { ParsedRuleDefinition, RecordUpdate, RuleKeyEntry, RuleRecord } from '../../../shared/insurance/models.js';
 import {
   InsuranceRuleConvertCommand,
   InsuranceRuleConvertResult,
@@ -30,6 +30,9 @@ type UnderwritingRuleRecord = RuleRecord & {
   DynamicRuleDefinition: string | null;
   RuleKey: string | null;
   UnderwritingRuleGroupId: string | null;
+  // Nested via the UnderwritingRuleGroup relationship so we can stamp the group's Name into the
+  // record-update file as an apply-time identity guard (we never write to a group blind by Id).
+  UnderwritingRuleGroup: { Name: string | null } | null;
 };
 
 export type CmlConvertUnderwritingRulesResult = InsuranceRuleConvertResult;
@@ -56,7 +59,8 @@ export default class CmlConvertUnderwritingRules extends InsuranceRuleConvertCom
   // DynamicRuleDefinition is a non-filterable (long text) field, so it can't appear in the
   // WHERE clause; records with a null DynamicRuleDefinition are skipped during parsing instead.
   protected readonly soql =
-    'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, RuleKey, UnderwritingRuleGroupId FROM UnderwritingRule WHERE RuleKey = null';
+    'SELECT Id, Name, ApiName, DynamicRuleDefinition, ProductPath, RuleKey, UnderwritingRuleGroupId, UnderwritingRuleGroup.Name FROM UnderwritingRule WHERE RuleKey = null';
+  protected readonly recordUpdateKind = 'underwriting-update' as const;
 
   public async run(): Promise<CmlConvertUnderwritingRulesResult> {
     const { flags } = await this.parse(CmlConvertUnderwritingRules);
@@ -96,49 +100,43 @@ export default class CmlConvertUnderwritingRules extends InsuranceRuleConvertCom
     }
   }
 
-  protected async updateOrgRecords(
-    records: UnderwritingRuleRecord[],
-    ruleKeyMapping: RuleKeyEntry[],
-    conn: Connection
-  ): Promise<void> {
-    const groupIds = new Set<string>();
+  /**
+   * Pure transform — the file-only successor to the old live updateOrgRecords. Produces the exact
+   * org-record changes convert previously applied: (1) each UnderwritingRuleGroup flipped to
+   * RuleEngineType=ConstraintEngine, then (2) each BRE UnderwritingRule's DynamicRuleDefinition blob
+   * rewritten with the converted ruleKey (and the nested underwritingRuleGroup.ruleEngineType, when
+   * present). Groups are emitted first so a faithful apply mirrors the original ordering. The blob
+   * rewrite uses a RAW JSON.parse of the org's stored value (NOT decodeHtmlEntities) — byte-for-byte
+   * the same mutation the live path performed.
+   */
+  protected buildRecordUpdates(records: UnderwritingRuleRecord[], ruleKeyMapping: RuleKeyEntry[]): RecordUpdate[] {
+    const updates: RecordUpdate[] = [];
+
+    // (1) UnderwritingRuleGroup flips — union of every referenced group, name resolved from the
+    // queried relationship so the apply-time identity guard has something to cross-check.
+    const groupNames = new Map<string, string | null>();
     for (const record of records) {
       if (record.UnderwritingRuleGroupId) {
-        groupIds.add(record.UnderwritingRuleGroupId);
+        groupNames.set(record.UnderwritingRuleGroupId, record.UnderwritingRuleGroup?.Name ?? null);
       }
     }
-
-    if (groupIds.size > 0) {
-      this.log(`\nUpdating ${groupIds.size} UnderwritingRuleGroup records with RuleEngineType=ConstraintEngine...`);
-      const groupUpdates = Array.from(groupIds).map((id) => ({
-        Id: id,
-        RuleEngineType: 'ConstraintEngine',
-      }));
-      const groupResults = await conn.sobject('UnderwritingRuleGroup').update(groupUpdates);
-      const groupList = Array.isArray(groupResults) ? groupResults : [groupResults];
-      const groupSuccesses = groupList.filter((r) => r.success);
-      const groupFailures = groupList.filter((r) => !r.success);
-      this.log(`  Updated ${groupSuccesses.length} group records`);
-      for (const f of groupFailures) {
-        this.warn(`  Failed to update group ${f.id ?? 'unknown'}: ${JSON.stringify(f.errors)}`);
+    for (const [groupId, groupName] of groupNames) {
+      if (!groupName) {
+        // Without a Name the apply can't run its identity guard; skip rather than write blind.
+        this.warn(`Skipping UnderwritingRuleGroup ${groupId}: no Name resolved (cannot verify identity on apply)`);
+        continue;
       }
+      updates.push({
+        sobject: 'UnderwritingRuleGroup',
+        id: groupId,
+        name: groupName,
+        fields: [{ field: 'RuleEngineType', value: 'ConstraintEngine' }],
+      });
     }
 
+    // (2) UnderwritingRule DynamicRuleDefinition rewrites — same subset and same mutation as live.
     const ruleKeyMap = new Map(ruleKeyMapping.map((m) => [m.recordId, m.ruleKey]));
     const breRecords = records.filter((r) => !r.RuleKey && r.DynamicRuleDefinition);
-
-    if (breRecords.length === 0) {
-      this.log('\nNo BRE rules to update with RuleKey.');
-      return;
-    }
-
-    this.log(
-      `\nUpdating ${breRecords.length} UnderwritingRule DynamicRuleDefinition with ruleKey and ruleEngineType...`
-    );
-    let successCount = 0;
-    let failCount = 0;
-
-    const updates: Array<{ Id: string; DynamicRuleDefinition: string }> = [];
     for (const record of breRecords) {
       const ruleKey = ruleKeyMap.get(record.Id);
       if (!ruleKey || !record.DynamicRuleDefinition) continue;
@@ -149,25 +147,18 @@ export default class CmlConvertUnderwritingRules extends InsuranceRuleConvertCom
         if (defn.underwritingRuleGroup && typeof defn.underwritingRuleGroup === 'object') {
           (defn.underwritingRuleGroup as Record<string, unknown>).ruleEngineType = 'ConstraintEngine';
         }
-        updates.push({ Id: record.Id, DynamicRuleDefinition: JSON.stringify(defn) });
+        updates.push({
+          sobject: 'UnderwritingRule',
+          id: record.Id,
+          name: record.Name,
+          apiName: record.ApiName ?? undefined,
+          fields: [{ field: 'DynamicRuleDefinition', value: JSON.stringify(defn) }],
+        });
       } catch {
         this.warn(`  Failed to parse DynamicRuleDefinition for ${record.Name}`);
-        failCount++;
       }
     }
 
-    if (updates.length > 0) {
-      const results = await conn.sobject('UnderwritingRule').update(updates);
-      for (const r of Array.isArray(results) ? results : [results]) {
-        if (r.success) {
-          successCount++;
-        } else {
-          failCount++;
-          this.warn(`  Failed to update ${r.id ?? 'unknown'}: ${JSON.stringify(r.errors)}`);
-        }
-      }
-    }
-
-    this.log(`  Updated ${successCount} rule records, ${failCount} failed`);
+    return updates;
   }
 }

--- a/src/shared/insurance/insurance-cml-merge.ts
+++ b/src/shared/insurance/insurance-cml-merge.ts
@@ -18,7 +18,7 @@ import { CmlConstraint } from '../types/types.js';
 import { ParsedRuleDefinition, RuleRecord } from './models.js';
 import {
   buildConstraintDeclaration,
-  collectAttributes,
+  collectEmittedAttributes,
   sanitizeName,
   buildStageTransition,
 } from './insurance-rule-generator.js';
@@ -153,27 +153,32 @@ function escapeRegExp(value: string): string {
 type TypeBlock = { openIdx: number; closeIdx: number };
 
 /**
- * Locates a `type <name> [: Parent] { ... }` block and returns the index of its opening brace and
- * its brace-matched closing brace. Block-less forward declarations (`type X : Y;`) are skipped
- * because the regex requires a `{` before any `;`. Word-boundary after the name keeps `Auto` from
- * matching `AutoSilver`/`AutoDriver`.
+ * Brace-matches the block whose opening `{` is at `openIdx` and returns the index of its matched
+ * closing `}`. The scanner ignores `{`/`}`/`"` that appear inside double-quoted string literals,
+ * `//` line comments, and `/* *\/` block comments — a curated Gold-Standard model routinely carries
+ * comments, and a stray `}` inside one (or inside a quoted rule value) must NOT be mistaken for the
+ * structural close, which would return a too-early closeIdx and splice a new rule mid-statement.
  */
-function findTypeBlock(cml: string, typeName: string): TypeBlock | undefined {
-  const re = new RegExp(`(^|\\n)\\s*type\\s+${escapeRegExp(typeName)}\\b[^{;]*\\{`);
-  const m = re.exec(cml);
-  if (!m) return undefined;
-
-  const openIdx = cml.indexOf('{', m.index);
-  if (openIdx < 0) return undefined;
-
-  // Brace-match while skipping braces that appear inside double-quoted string literals (a CML rule
-  // declaration can carry an arbitrary string value such as `make == "weird}brace"`). Without this,
-  // a `}` inside a quoted value is mistaken for the block's closing brace and we return a too-early
-  // closeIdx, splicing the new rule into the middle of an existing statement.
+function matchClosingBrace(cml: string, openIdx: number): number | undefined {
   let depth = 0;
   let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
   for (let i = openIdx; i < cml.length; i++) {
     const ch = cml[i];
+    const next = cml[i + 1];
+
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
     if (inString) {
       if (ch === '\\') {
         i++; // skip the escaped character
@@ -182,14 +187,51 @@ function findTypeBlock(cml: string, typeName: string): TypeBlock | undefined {
       }
       continue;
     }
-    if (ch === '"') inString = true;
-    else if (ch === '{') depth++;
-    else if (ch === '}') {
+
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+    } else if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+    } else if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
       depth--;
-      if (depth === 0) return { openIdx, closeIdx: i };
+      if (depth === 0) return i;
     }
   }
   return undefined;
+}
+
+/**
+ * Locates a `type <name> [: Parent] { ... }` block and returns the index of its opening brace and
+ * its brace-matched closing brace. Block-less forward declarations (`type X : Y;`) are skipped
+ * because the regex requires a `{` before any `;`. Word-boundary after the name keeps `Auto` from
+ * matching `AutoSilver`/`AutoDriver`.
+ *
+ * M1/M5: when more than one block declares the same type name the result is AMBIGUOUS — rather than
+ * guessing the first lexical match (which could nest the surcharge under the wrong product), the
+ * caller is told via `undefined` + a distinct ambiguity reason. A single unique match resolves
+ * normally.
+ */
+function findTypeBlock(cml: string, typeName: string): TypeBlock | { ambiguous: true } | undefined {
+  const re = new RegExp(`(^|\\n)[ \\t]*type[ \\t]+${escapeRegExp(typeName)}\\b[^{;]*\\{`, 'g');
+  const matches: number[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cml)) !== null) {
+    const openIdx = cml.indexOf('{', m.index);
+    if (openIdx >= 0) matches.push(openIdx);
+  }
+  if (matches.length === 0) return undefined;
+  if (matches.length > 1) return { ambiguous: true };
+
+  const openIdx = matches[0];
+  const closeIdx = matchClosingBrace(cml, openIdx);
+  if (closeIdx === undefined) return undefined;
+  return { openIdx, closeIdx };
 }
 
 /** Builds the `rule(...)` statement for a surcharge, using the same constraint generator as build mode. */
@@ -219,7 +261,10 @@ export function buildPathedSurchargeRules(
 
     const declaration = buildConstraintDeclaration(ruleDef);
     const statement = buildSurchargeRuleStatement(declaration, ruleKey);
-    const referencedAttributes = Array.from(collectAttributes([{ ruleDef }])).map(sanitizeName);
+    // M7: only attributes from conditions that actually emitted CML (non-null buildConditionExpression)
+    // count as "referenced". Attributes from conditions the safe-literal guard / unknown-operator
+    // filter dropped never appear in the declaration, so warning about them would be spurious noise.
+    const referencedAttributes = Array.from(collectEmittedAttributes([{ ruleDef }]));
 
     return {
       recordId: record.Id,
@@ -251,19 +296,32 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
   // same way), so checking the mutated text would always find it and suppress every warning.
   const baseCml = existingCml;
 
-  for (const rule of rules) {
-    const quotedKey = `"${rule.ruleKey}"`;
-    const keyIdx = cml.indexOf(quotedKey);
+  // H1: keys this run has already placed. A second rule resolving to the same pathed key must be
+  // reported as a collision skip, NOT treated as an idempotent replace of the first rule's
+  // just-inserted statement (which would silently drop the second record's distinct declaration).
+  const placedKeys = new Set<string>();
 
-    if (keyIdx >= 0) {
-      // Replace the whole line that carries this key (rule statements are single-line here).
-      const lineStart = cml.lastIndexOf('\n', keyIdx) + 1;
-      let lineEnd = cml.indexOf('\n', keyIdx);
-      if (lineEnd < 0) lineEnd = cml.length;
-      const indentMatch = /^\s*/.exec(cml.slice(lineStart, lineEnd));
+  for (const rule of rules) {
+    if (placedKeys.has(rule.ruleKey)) {
+      skips.push({
+        rule,
+        reason: `duplicate pathed rule key '${rule.ruleKey}' collides with another rule in this run (${rule.recordName} skipped)`,
+      });
+      continue;
+    }
+
+    // C2/M4/L1: only a REAL surcharge `rule(...)` statement carrying this exact key in the
+    // action-scope slot counts as "present". A bare quoted-key substring inside an unrelated rule's
+    // value, a longer key, or a comment must NOT trigger a destructive line replace.
+    const stmt = findSurchargeStatement(cml, rule.ruleKey);
+
+    if (stmt) {
+      // L2: preserve the original line ending (CRLF vs LF) of the replaced line.
+      const indentMatch = /^[ \t]*/.exec(cml.slice(stmt.lineStart, stmt.lineEnd));
       const indent = indentMatch ? indentMatch[0] : '    ';
-      cml = cml.slice(0, lineStart) + indent + rule.statement + cml.slice(lineEnd);
+      cml = cml.slice(0, stmt.lineStart) + indent + rule.statement + cml.slice(stmt.lineEnd);
       placements.push({ rule, status: 'replaced' });
+      placedKeys.add(rule.ruleKey);
       collectAttributeWarning(baseCml, rule, attributeWarnings);
       continue;
     }
@@ -278,15 +336,122 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
       skips.push({ rule, reason: `type block '${rule.typeName}' not found in existing model` });
       continue;
     }
+    if ('ambiguous' in block) {
+      skips.push({
+        rule,
+        reason: `type block '${rule.typeName}' is ambiguous (multiple/duplicate declarations) in existing model; skipping ${rule.recordName} rather than guessing`,
+      });
+      continue;
+    }
 
     // Insert before the closing brace, indented one level (4 spaces), with a leading blank line.
     const insertion = `\n    ${rule.statement}\n`;
     cml = cml.slice(0, block.closeIdx) + insertion + cml.slice(block.closeIdx);
     placements.push({ rule, status: 'inserted' });
+    placedKeys.add(rule.ruleKey);
     collectAttributeWarning(baseCml, rule, attributeWarnings);
   }
 
   return { mergedCml: cml, placements, skips, attributeWarnings };
+}
+
+type StatementMatch = { lineStart: number; lineEnd: number };
+
+/**
+ * C2/M4/L1: finds the single-line surcharge `rule(...)` statement that carries `ruleKey` in the
+ * action-scope slot — i.e. `rule(<decl>, "InsuranceSurchargeRule", "<ruleKey>", ...`. Only such a
+ * real statement is a legitimate replace target. A bare `"<ruleKey>"` substring appearing inside an
+ * unrelated rule's VALUE, inside a `//` line comment, inside a `/* *\/` block comment, or as part of
+ * a LONGER key is deliberately NOT matched, so the caller falls through to the insert path instead of
+ * clobbering curated text.
+ *
+ * Comment-awareness: the anchor scan runs against a length-preserving COPY of `cml` in which every
+ * character inside a `//`/`/* *\/` comment is blanked to a space (newlines kept). Offsets into that
+ * copy therefore map 1:1 onto the original, so the returned line span still slices the real text —
+ * but a rule-shaped string sitting inside a (single- or multi-line) block comment can no longer match
+ * the anchor and be clobbered.
+ *
+ * Returns the start/end offsets of the matched line (lineEnd points at the newline / EOF, excluding
+ * any trailing `\r` so the caller can re-emit the original CRLF/LF).
+ */
+function findSurchargeStatement(cml: string, ruleKey: string): StatementMatch | undefined {
+  const anchor = new RegExp(
+    `rule\\([^;\\r\\n]*"${escapeRegExp(SURCHARGE_RULE_ACTION)}"\\s*,\\s*"${escapeRegExp(ruleKey)}"\\s*,`
+  );
+  // Comment-blanked, length-preserving view of the model: matching against this view ignores any
+  // rule-shaped text that lives inside `//` or `/* */` comments while keeping every offset aligned
+  // with the original `cml` so the returned span still references the real (un-blanked) text.
+  const scan = blankComments(cml);
+  let lineStart = 0;
+  while (lineStart <= scan.length) {
+    const nl = scan.indexOf('\n', lineStart);
+    const rawEnd = nl < 0 ? scan.length : nl;
+    const line = scan.slice(lineStart, rawEnd);
+    if (anchor.test(line)) {
+      // Strip a trailing \r from the matched line span so CRLF can be preserved by the caller.
+      const lineEnd = rawEnd > lineStart && cml[rawEnd - 1] === '\r' ? rawEnd - 1 : rawEnd;
+      return { lineStart, lineEnd };
+    }
+    if (nl < 0) break;
+    lineStart = nl + 1;
+  }
+  return undefined;
+}
+
+/**
+ * Returns a copy of `cml` with identical length where every character inside a `//` line comment or
+ * a `/* *\/` block comment is replaced by a space (newlines preserved). Used so the replace-anchor
+ * scan can ignore comment contents without losing offset alignment with the original text. String
+ * literals are left intact: the anchor itself requires the literal `"InsuranceSurchargeRule"` action
+ * token, so a same-key VALUE inside another rule's string still won't satisfy the action-scope shape.
+ */
+function blankComments(cml: string): string {
+  const out = cml.split('');
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = 0; i < cml.length; i++) {
+    const ch = cml[i];
+    const next = cml[i + 1];
+    if (inLineComment) {
+      if (ch === '\n') inLineComment = false;
+      else out[i] = ' ';
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        out[i] = ' ';
+        out[i + 1] = ' ';
+        i++;
+        inBlockComment = false;
+      } else if (ch !== '\n') {
+        out[i] = ' ';
+      }
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip escaped char (left intact)
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      out[i] = ' ';
+      out[i + 1] = ' ';
+      i++;
+    } else if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      out[i] = ' ';
+      out[i + 1] = ' ';
+      i++;
+    } else if (ch === '"') {
+      inString = true;
+    }
+  }
+  return out.join('');
 }
 
 /**
@@ -300,10 +465,104 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
  * just-inserted declaration (which sanitizes attribute names identically), suppressing every warning.
  */
 function collectAttributeWarning(baseCml: string, rule: PathedSurchargeRule, warnings: string[]): void {
+  // H5/M3: scope the presence check to the leaf type block plus its `: Parent` ancestry, with
+  // comments and string literals stripped. CML attribute visibility is hierarchy-scoped, so an
+  // unscoped whole-file `\battr\b` test gives false negatives (an attribute named only in a comment,
+  // a string value, or an unrelated SIBLING type would wrongly suppress a real absent-attribute
+  // warning).
+  //
+  // H5 (fallback facet): when the leaf scope can't be resolved — typeName is undefined, or the leaf
+  // `type` block is ambiguous/duplicate so collectTypeScopeText returns undefined — we have NO
+  // hierarchy-scoped view to prove the attribute is visible. We must NOT widen to the whole model
+  // (that re-introduces the sibling-type false negative on exactly the records that hit the replace
+  // path before type resolution). Fail VISIBLE instead: treat the scope as empty so an attribute we
+  // cannot prove visible is reported, never silently suppressed.
+  const scope = rule.typeName ? collectTypeScopeText(baseCml, rule.typeName) ?? '' : '';
+
   for (const attr of rule.referencedAttributes) {
-    const present = new RegExp(`\\b${escapeRegExp(attr)}\\b`).test(baseCml);
+    const present = new RegExp(`\\b${escapeRegExp(attr)}\\b`).test(scope);
     if (!present) {
       warnings.push(`${rule.recordName}: declaration references '${attr}' which is absent from the model`);
     }
   }
+}
+
+/**
+ * Removes `//` line comments, `/* *\/` block comments, and double-quoted string-literal CONTENTS
+ * from CML text so that attribute-presence checks match only real declarations/expressions, never a
+ * name that merely appears in a comment or a string value. String delimiters are kept so structure
+ * is preserved; only the interior characters are blanked.
+ */
+function stripCommentsAndStrings(cml: string): string {
+  let out = '';
+  let inString = false;
+  let inLineComment = false;
+  let inBlockComment = false;
+  for (let i = 0; i < cml.length; i++) {
+    const ch = cml[i];
+    const next = cml[i + 1];
+    if (inLineComment) {
+      if (ch === '\n') {
+        inLineComment = false;
+        out += ch;
+      }
+      continue;
+    }
+    if (inBlockComment) {
+      if (ch === '*' && next === '/') {
+        inBlockComment = false;
+        i++;
+      }
+      continue;
+    }
+    if (inString) {
+      if (ch === '\\') {
+        i++; // skip escaped char (and drop it)
+      } else if (ch === '"') {
+        inString = false;
+        out += '"';
+      }
+      continue;
+    }
+    if (ch === '/' && next === '/') {
+      inLineComment = true;
+      i++;
+    } else if (ch === '/' && next === '*') {
+      inBlockComment = true;
+      i++;
+    } else if (ch === '"') {
+      inString = true;
+      out += '"';
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+/**
+ * Builds the comment/string-stripped text of the leaf `type <name> { ... }` block plus every
+ * `: Parent` ancestor block reachable in the model, concatenated. Returns undefined when the leaf
+ * block can't be resolved (or is ambiguous), so the caller can fall back. Bounded against cycles by
+ * a visited set.
+ */
+function collectTypeScopeText(cml: string, leafType: string, visited = new Set<string>()): string | undefined {
+  if (visited.has(leafType)) return '';
+  visited.add(leafType);
+
+  const block = findTypeBlock(cml, leafType);
+  if (!block || 'ambiguous' in block) return undefined;
+
+  const headerStart = cml.lastIndexOf('\n', block.openIdx) + 1;
+  const header = cml.slice(headerStart, block.openIdx);
+  const body = cml.slice(block.openIdx, block.closeIdx + 1);
+  let text = stripCommentsAndStrings(body);
+
+  // Resolve `type Leaf : Parent {` ancestry and append parent scope(s).
+  const parentMatch = /:\s*([A-Za-z_]\w*)/.exec(header);
+  if (parentMatch) {
+    const parentText = collectTypeScopeText(cml, parentMatch[1], visited);
+    if (parentText) text += '\n' + parentText;
+  }
+  return text;
 }

--- a/src/shared/insurance/insurance-cml-merge.ts
+++ b/src/shared/insurance/insurance-cml-merge.ts
@@ -47,6 +47,13 @@ export type PathedSurchargeRule = {
   apiName: string;
   /** Full pathed key: SC__<code-of-each-path-segment>__<apiName>. */
   ruleKey: string;
+  /**
+   * Ordered ProductCodes for every ProductPath segment used to build {@link ruleKey}. Empty when the
+   * source ProductPath was blank/whitespace-only — the merge guards on this to refuse the replace
+   * path for malformed input (an empty-path rule degenerates to `SC__<apiName>` which could
+   * coincidentally match a curated short-keyed line).
+   */
+  pathProductCodes: string[];
   /** Leaf CML type name (ConstraintModelTag of the LAST ProductPath segment). */
   typeName: string | undefined;
   /** The generated `rule(<decl>, "InsuranceSurchargeRule", "<ruleKey>", "True");` statement. */
@@ -150,6 +157,21 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * [Fix #4] Detects the dominant line ending of a CML text by counting CRLF vs bare-LF occurrences.
+ * Returns `\r\n` when at least one CRLF appears AND CRLFs are at least as common as bare LFs (mixed
+ * CRLF-majority files still get CRLF; pure-LF and empty files get `\n`). Used by the INSERT path so
+ * a CRLF-curated model stays byte-clean after splicing. The L2 replace path preserves the line
+ * ending of the REPLACED span directly, so this only matters for new inserts.
+ */
+function detectDominantLineEnding(cml: string): string {
+  const crlfCount = (cml.match(/\r\n/g) ?? []).length;
+  // Subtract CRLFs from the total LF count to get the BARE-LF count (an LF preceded by CR is part of a CRLF).
+  const totalLf = (cml.match(/\n/g) ?? []).length;
+  const bareLfCount = totalLf - crlfCount;
+  return crlfCount > 0 && crlfCount >= bareLfCount ? '\r\n' : '\n';
+}
+
 type TypeBlock = { openIdx: number; closeIdx: number };
 
 /**
@@ -217,12 +239,24 @@ function matchClosingBrace(cml: string, openIdx: number): number | undefined {
  * caller is told via `undefined` + a distinct ambiguity reason. A single unique match resolves
  * normally.
  */
-function findTypeBlock(cml: string, typeName: string): TypeBlock | { ambiguous: true } | undefined {
+function findTypeBlock(
+  cml: string,
+  typeName: string,
+  scan: string = blankComments(cml)
+): TypeBlock | { ambiguous: true } | undefined {
+  // [Fix #1] Run the anchor regex against the comment-blanked, length-preserving SCAN view rather
+  // than the raw cml. matchClosingBrace below is comment-aware; if the anchor regex ran on raw cml a
+  // commented-out `type Collision { ... }` header could be picked up as a real declaration (and then
+  // matchClosingBrace, which ignores comment braces, would either return the WRONG closeIdx or
+  // confuse a real same-name type for an "ambiguous" duplicate). The scan view zeroes the comment
+  // characters to spaces while preserving offsets, so the indices returned here still slice the
+  // real cml correctly. The default-argument pattern lets callers reuse a single hoisted scan
+  // across multiple lookups (Fix #1 hoisting site).
   const re = new RegExp(`(^|\\n)[ \\t]*type[ \\t]+${escapeRegExp(typeName)}\\b[^{;]*\\{`, 'g');
   const matches: number[] = [];
   let m: RegExpExecArray | null;
-  while ((m = re.exec(cml)) !== null) {
-    const openIdx = cml.indexOf('{', m.index);
+  while ((m = re.exec(scan)) !== null) {
+    const openIdx = scan.indexOf('{', m.index);
     if (openIdx >= 0) matches.push(openIdx);
   }
   if (matches.length === 0) return undefined;
@@ -271,6 +305,7 @@ export function buildPathedSurchargeRules(
       recordName: record.Name,
       apiName,
       ruleKey,
+      pathProductCodes: pathCodes,
       typeName,
       statement,
       referencedAttributes,
@@ -295,6 +330,16 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
   // statement always contains its referenced attribute (the declaration sanitizes attribute names the
   // same way), so checking the mutated text would always find it and suppress every warning.
   const baseCml = existingCml;
+  // [Fix #1] Comment-blanked, length-preserving view of the BASELINE cml — shared by every
+  // collectTypeScopeText / baseline lookup so the attribute-presence anchor regex ignores comment
+  // contents without losing offset alignment. The per-iteration scan for findTypeBlock /
+  // findSurchargeStatement is computed against the current (possibly mutated) `cml` inside the loop.
+  const baseScan = blankComments(baseCml);
+  // [Fix #4] Detect the dominant line ending ONCE so the INSERT path can splice in the model's own
+  // convention (CRLF on Windows-curated files, LF elsewhere). Before this, a hardcoded `\n` mixed
+  // bare LFs into a CRLF model and produced a byte-unclean diff. The L2 replace path already
+  // preserves the original line ending of the replaced span; this guard does the same for inserts.
+  const eol = detectDominantLineEnding(existingCml);
 
   // H1: keys this run has already placed. A second rule resolving to the same pathed key must be
   // reported as a collision skip, NOT treated as an idempotent replace of the first rule's
@@ -310,28 +355,49 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
       continue;
     }
 
-    // C2/M4/L1: only a REAL surcharge `rule(...)` statement carrying this exact key in the
-    // action-scope slot counts as "present". A bare quoted-key substring inside an unrelated rule's
-    // value, a longer key, or a comment must NOT trigger a destructive line replace.
-    const stmt = findSurchargeStatement(cml, rule.ruleKey);
-
-    if (stmt) {
-      // L2: preserve the original line ending (CRLF vs LF) of the replaced line.
-      const indentMatch = /^[ \t]*/.exec(cml.slice(stmt.lineStart, stmt.lineEnd));
-      const indent = indentMatch ? indentMatch[0] : '    ';
-      cml = cml.slice(0, stmt.lineStart) + indent + rule.statement + cml.slice(stmt.lineEnd);
-      placements.push({ rule, status: 'replaced' });
-      placedKeys.add(rule.ruleKey);
-      collectAttributeWarning(baseCml, rule, attributeWarnings);
+    // [Fix #3] Refuse the destructive replace path for malformed/empty-ProductPath input. An empty
+    // pathProductCodes degenerates the rule key to `SC__<apiName>`, which could COINCIDENTALLY match
+    // a curated short-keyed line and clobber it; an absent typeName means we'd have nowhere to
+    // re-insert and would also have no way to scope the replace to the correct block. Short-circuit
+    // these as skips BEFORE findSurchargeStatement runs so a malformed surcharge can never reach the
+    // replace splice. The pre-existing intra-run duplicate guard above is preserved.
+    if (rule.pathProductCodes.length === 0) {
+      skips.push({
+        rule,
+        reason: `empty ProductPath for ${rule.recordName}; refusing to merge a non-pathed surcharge`,
+      });
       continue;
     }
-
     if (!rule.typeName) {
       skips.push({ rule, reason: `no CML type tag found for the leaf product of ${rule.recordName}` });
       continue;
     }
 
-    const block = findTypeBlock(cml, rule.typeName);
+    // [Fix #1] One comment-blanked view of the current `cml` reused by both the replace-anchor
+    // search and the type-block search this iteration. Recomputed per-iteration because a prior
+    // rule's splice may have mutated `cml`.
+    const scan = blankComments(cml);
+
+    // C2/M4/L1: only a REAL surcharge `rule(...)` statement carrying this exact key in the
+    // action-scope slot counts as "present". A bare quoted-key substring inside an unrelated rule's
+    // value, a longer key, or a comment must NOT trigger a destructive line replace.
+    const stmt = findSurchargeStatement(cml, rule.ruleKey, scan);
+
+    if (stmt) {
+      // [Fix #2] Splice ONLY the matched statement span (`rule(...);`) rather than the entire
+      // physical line. A curated line carrying two `rule(...);` statements (rare but valid) keeps
+      // the unrelated statement intact. Block formatting is preserved as long as the matched
+      // statement is the only thing on its line (the common case): the original indent prefix lives
+      // in `cml[lineStart..stmt.start)` and is left untouched by the splice; only `cml[start..end)`
+      // is replaced. If other code shares the line, that code stays in place verbatim too.
+      cml = cml.slice(0, stmt.start) + rule.statement + cml.slice(stmt.end);
+      placements.push({ rule, status: 'replaced' });
+      placedKeys.add(rule.ruleKey);
+      collectAttributeWarning(baseCml, rule, attributeWarnings, baseScan);
+      continue;
+    }
+
+    const block = findTypeBlock(cml, rule.typeName, scan);
     if (!block) {
       skips.push({ rule, reason: `type block '${rule.typeName}' not found in existing model` });
       continue;
@@ -345,17 +411,28 @@ export function mergeSurchargeRules(existingCml: string, rules: PathedSurchargeR
     }
 
     // Insert before the closing brace, indented one level (4 spaces), with a leading blank line.
-    const insertion = `\n    ${rule.statement}\n`;
+    // [Fix #4] Use the dominant line ending of the original model, not a hardcoded `\n`.
+    const insertion = `${eol}    ${rule.statement}${eol}`;
     cml = cml.slice(0, block.closeIdx) + insertion + cml.slice(block.closeIdx);
     placements.push({ rule, status: 'inserted' });
     placedKeys.add(rule.ruleKey);
-    collectAttributeWarning(baseCml, rule, attributeWarnings);
+    collectAttributeWarning(baseCml, rule, attributeWarnings, baseScan);
   }
 
   return { mergedCml: cml, placements, skips, attributeWarnings };
 }
 
-type StatementMatch = { lineStart: number; lineEnd: number };
+/**
+ * [Fix #2] Precise span of a matched surcharge statement.
+ *
+ * - `start`  — offset of the matched `rule(` token in the original cml
+ * - `end`    — offset just AFTER the terminating `;` (so cml.slice(start, end) is the whole statement)
+ *
+ * The previous shape (`lineStart..lineEnd`) replaced the entire physical line, which silently
+ * clobbered any OTHER `rule(...);` statement that happened to share that line. The precise span
+ * splices ONLY the matched statement and leaves other statements on the same line intact.
+ */
+type StatementMatch = { start: number; end: number };
 
 /**
  * C2/M4/L1: finds the single-line surcharge `rule(...)` statement that carries `ruleKey` in the
@@ -374,26 +451,63 @@ type StatementMatch = { lineStart: number; lineEnd: number };
  * Returns the start/end offsets of the matched line (lineEnd points at the newline / EOF, excluding
  * any trailing `\r` so the caller can re-emit the original CRLF/LF).
  */
-function findSurchargeStatement(cml: string, ruleKey: string): StatementMatch | undefined {
+function findSurchargeStatement(
+  cml: string,
+  ruleKey: string,
+  scan: string = blankComments(cml)
+): StatementMatch | undefined {
+  // [Fix #2] Match the surcharge rule statement and return the PRECISE span from the `rule(` token
+  // to just past its terminating `;`. The previous implementation returned a whole-line span which
+  // clobbered any OTHER `rule(...);` statement sharing the same physical line. The global flag is
+  // required so a coincidental earlier match (e.g. an unrelated rule whose VALUE quotes the key
+  // before the real statement) can be skipped by walking to subsequent matches via `exec`. We do
+  // NOT use a single-line anchor: a real surcharge statement is single-line by convention, but the
+  // anchor's `[^;\r\n]*` constraint already guarantees the prefix is single-line; what matters here
+  // is bounding the SPAN, not the search.
   const anchor = new RegExp(
-    `rule\\([^;\\r\\n]*"${escapeRegExp(SURCHARGE_RULE_ACTION)}"\\s*,\\s*"${escapeRegExp(ruleKey)}"\\s*,`
+    `rule\\([^;\\r\\n]*"${escapeRegExp(SURCHARGE_RULE_ACTION)}"\\s*,\\s*"${escapeRegExp(ruleKey)}"\\s*,`,
+    'g'
   );
-  // Comment-blanked, length-preserving view of the model: matching against this view ignores any
-  // rule-shaped text that lives inside `//` or `/* */` comments while keeping every offset aligned
-  // with the original `cml` so the returned span still references the real (un-blanked) text.
-  const scan = blankComments(cml);
-  let lineStart = 0;
-  while (lineStart <= scan.length) {
-    const nl = scan.indexOf('\n', lineStart);
-    const rawEnd = nl < 0 ? scan.length : nl;
-    const line = scan.slice(lineStart, rawEnd);
-    if (anchor.test(line)) {
-      // Strip a trailing \r from the matched line span so CRLF can be preserved by the caller.
-      const lineEnd = rawEnd > lineStart && cml[rawEnd - 1] === '\r' ? rawEnd - 1 : rawEnd;
-      return { lineStart, lineEnd };
+  let m: RegExpExecArray | null;
+  while ((m = anchor.exec(scan)) !== null) {
+    const start = m.index;
+    // Walk forward in the SCAN view (comment chars blanked) to find the terminating `;`. Using scan
+    // keeps a `;` that lives inside a `// ...` or `/* ... */` comment from terminating the span.
+    // String-literal contents within the statement are kept intact by blankComments, so a `;` inside
+    // a quoted RHS value is also ignored — find the structural `;` by walking past string literals.
+    const semi = findStructuralSemicolon(scan, m.index + m[0].length);
+    if (semi === undefined) {
+      // Malformed unterminated rule(...) — refuse to splice rather than guessing.
+      return undefined;
     }
-    if (nl < 0) break;
-    lineStart = nl + 1;
+    return { start, end: semi + 1 };
+  }
+  return undefined;
+}
+
+/**
+ * [Fix #2] Walks forward from `from` returning the index of the structural `;` terminating the
+ * current statement. The scan is comment-blanked, so `;` inside `//` or `/* *\/` cannot terminate.
+ * Double-quoted string literals are still present in the scan (blankComments only blanks comments);
+ * skip them here so a `;` inside a quoted value is ignored.
+ */
+function findStructuralSemicolon(scan: string, from: number): number | undefined {
+  let inString = false;
+  for (let i = from; i < scan.length; i++) {
+    const ch = scan[i];
+    if (inString) {
+      if (ch === '\\') {
+        i++;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === ';') {
+      return i;
+    }
   }
   return undefined;
 }
@@ -464,7 +578,12 @@ function blankComments(cml: string): string {
  * spliced in. Checking the post-insertion text would always find the attribute inside the rule's own
  * just-inserted declaration (which sanitizes attribute names identically), suppressing every warning.
  */
-function collectAttributeWarning(baseCml: string, rule: PathedSurchargeRule, warnings: string[]): void {
+function collectAttributeWarning(
+  baseCml: string,
+  rule: PathedSurchargeRule,
+  warnings: string[],
+  baseScan?: string
+): void {
   // H5/M3: scope the presence check to the leaf type block plus its `: Parent` ancestry, with
   // comments and string literals stripped. CML attribute visibility is hierarchy-scoped, so an
   // unscoped whole-file `\battr\b` test gives false negatives (an attribute named only in a comment,
@@ -477,7 +596,7 @@ function collectAttributeWarning(baseCml: string, rule: PathedSurchargeRule, war
   // (that re-introduces the sibling-type false negative on exactly the records that hit the replace
   // path before type resolution). Fail VISIBLE instead: treat the scope as empty so an attribute we
   // cannot prove visible is reported, never silently suppressed.
-  const scope = rule.typeName ? collectTypeScopeText(baseCml, rule.typeName) ?? '' : '';
+  const scope = rule.typeName ? collectTypeScopeText(baseCml, rule.typeName, undefined, baseScan) ?? '' : '';
 
   for (const attr of rule.referencedAttributes) {
     const present = new RegExp(`\\b${escapeRegExp(attr)}\\b`).test(scope);
@@ -546,11 +665,16 @@ function stripCommentsAndStrings(cml: string): string {
  * block can't be resolved (or is ambiguous), so the caller can fall back. Bounded against cycles by
  * a visited set.
  */
-function collectTypeScopeText(cml: string, leafType: string, visited = new Set<string>()): string | undefined {
+function collectTypeScopeText(
+  cml: string,
+  leafType: string,
+  visited = new Set<string>(),
+  scan: string = blankComments(cml)
+): string | undefined {
   if (visited.has(leafType)) return '';
   visited.add(leafType);
 
-  const block = findTypeBlock(cml, leafType);
+  const block = findTypeBlock(cml, leafType, scan);
   if (!block || 'ambiguous' in block) return undefined;
 
   const headerStart = cml.lastIndexOf('\n', block.openIdx) + 1;
@@ -561,7 +685,7 @@ function collectTypeScopeText(cml: string, leafType: string, visited = new Set<s
   // Resolve `type Leaf : Parent {` ancestry and append parent scope(s).
   const parentMatch = /:\s*([A-Za-z_]\w*)/.exec(header);
   if (parentMatch) {
-    const parentText = collectTypeScopeText(cml, parentMatch[1], visited);
+    const parentText = collectTypeScopeText(cml, parentMatch[1], visited, scan);
     if (parentText) text += '\n' + parentText;
   }
   return text;

--- a/src/shared/insurance/insurance-org.ts
+++ b/src/shared/insurance/insurance-org.ts
@@ -30,15 +30,36 @@ export function quoteSoqlIdList(ids: Iterable<string>): string {
     .join(',');
 }
 
-export async function fetchProductCodes(conn: Connection, productIds: Set<string>): Promise<Map<string, string>> {
+/** Optional hooks for {@link fetchProductCodes}. Additive so existing callers need no changes. */
+export type FetchProductCodesOptions = {
+  /**
+   * Invoked once per product id whose code had to be derived from a fallback (Name, then Id)
+   * because `ProductCode` was blank. The pathed rule key is built from these codes, so a fallback
+   * silently yields a key that will NOT match the platform's auto-generated RuleKey — the rule then
+   * imports cleanly but never fires. Surfacing the fallback lets the command layer warn instead of
+   * dropping the surcharge silently (M2).
+   */
+  onFallback?: (productId: string) => void;
+};
+
+export async function fetchProductCodes(
+  conn: Connection,
+  productIds: Set<string>,
+  options: FetchProductCodesOptions = {}
+): Promise<Map<string, string>> {
   const idToCode = new Map<string, string>();
   const idList = quoteSoqlIdList(productIds);
   if (!idList) return idToCode;
 
-  const result = await conn.query<{ Id: string; ProductCode: string; Name: string }>(
+  const result = await conn.query<{ Id: string; ProductCode: string | null; Name: string | null }>(
     `SELECT Id, ProductCode, Name FROM Product2 WHERE Id IN (${idList})`
   );
   for (const p of result.records) {
+    // Keep the fallback chain (don't break callers), but make it observable: a null ProductCode
+    // means the resolved code did NOT come from the platform-authoritative field.
+    if (p.ProductCode == null) {
+      options.onFallback?.(p.Id);
+    }
     idToCode.set(p.Id, p.ProductCode ?? p.Name ?? p.Id);
   }
   return idToCode;

--- a/src/shared/insurance/insurance-org.ts
+++ b/src/shared/insurance/insurance-org.ts
@@ -40,6 +40,13 @@ export type FetchProductCodesOptions = {
    * dropping the surcharge silently (M2).
    */
   onFallback?: (productId: string) => void;
+  /**
+   * When provided, populated with each product's Name (Id -> Name) from the same query. The common
+   * `cml import as-expression-set` resolves a Type association's Product2 by Name, so the convert
+   * layer must emit Name — not ProductCode — as the association reference value. Collected here to
+   * avoid a second round-trip. Products with a null Name are omitted (they cannot match by name).
+   */
+  collectNames?: Map<string, string>;
 };
 
 export async function fetchProductCodes(
@@ -61,6 +68,9 @@ export async function fetchProductCodes(
       options.onFallback?.(p.Id);
     }
     idToCode.set(p.Id, p.ProductCode ?? p.Name ?? p.Id);
+    if (p.Name != null) {
+      options.collectNames?.set(p.Id, p.Name);
+    }
   }
   return idToCode;
 }

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -17,13 +17,15 @@
 // This file is a shared abstract base, not a user-invocable command, so the
 // command-shape lint rules do not apply.
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { Connection, Messages, Org } from '@salesforce/core';
 import { CmlModel } from '../types/types.js';
 import { generateCsvForAssociations } from '../utils/association.utils.js';
-import { ParsedRuleDefinition, RuleKeyEntry, RuleRecord } from './models.js';
-import { buildCmlModel } from './insurance-rule-generator.js';
+import { ParsedRuleDefinition, RecordUpdate, RecordUpdatePlan, RuleKeyEntry, RuleRecord } from './models.js';
+import { buildCmlModel, isSafeAssociationReferenceValue, sanitizeName } from './insurance-rule-generator.js';
 import { discoverCmlApiByProducts, fetchProductCodes } from './insurance-org.js';
+import { splitProductPath } from './insurance-cml-merge.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.convert.insurance-shared');
@@ -34,10 +36,19 @@ const messages = Messages.loadMessages('@salesforce/plugin-bre-to-cml', 'cml.con
 const ASSOCIATIONS_CSV_HEADER =
   'ExpressionSet.ApiName,ConstraintModelTag,ConstraintModelTagType,ReferenceObjectId,$Product2ReferenceId,$ProductClassificationName,$ProductRelatedComponentKey';
 
+// File-name suffix per record-update kind. The convert commands emit `<safeApi>_<suffix>.json` as a
+// reviewable manifest of the org-record changes; this plugin does NOT apply it (convert is file-only).
+const RECORD_UPDATE_FILE_SUFFIX: Record<RecordUpdatePlan['kind'], string> = {
+  'underwriting-update': 'UnderwritingUpdate',
+  'surcharge-update': 'SurchargeUpdate',
+};
+
 export type InsuranceRuleConvertResult = {
   cmlFile: string;
   associationsFile: string;
   ruleKeyMapping: RuleKeyEntry[];
+  // Path to the emitted `<safeApi>_{Underwriting,Surcharge}Update.json` file (when one was written).
+  recordUpdateFile?: string;
 };
 
 export type InsuranceRuleConvertContext = {
@@ -82,7 +93,16 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
   protected abstract readonly apiNamePrefix: string;
   protected abstract readonly soql: string;
 
+  /** Discriminator that selects the on-disk file kind and name suffix for the emitted update file. */
+  protected abstract readonly recordUpdateKind: RecordUpdatePlan['kind'];
+
   protected async runConvert(ctx: InsuranceRuleConvertContext): Promise<InsuranceRuleConvertResult> {
+    // Tripwire: convert is now strictly file-only. The legacy --update-records flag mutated the org
+    // as a side effect; it is removed, and passing it errors with a pointer to the new flow.
+    if (ctx.updateRecords) {
+      throw messages.createError('error.updateRecordsRemoved');
+    }
+
     const workspaceDir = ctx.workspaceDir ?? '.';
     this.log(`Using Workspace Directory: ${ctx.workspaceDir ?? 'not specified'}`);
     const conn = ctx.targetOrg.getConnection(ctx.apiVersion);
@@ -90,11 +110,19 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     const records = await this.loadRecords(conn, ctx.inputFile);
     if (records.length === 0) {
       this.log(`No ${this.recordLabel} rules to convert.`);
+      // Still emit an (empty) record-update manifest when we can name it, so automation always has a
+      // concrete file to consume. Without --cml-api there are no products to discover an API name
+      // from, so there is nothing to name the file after.
+      if (ctx.cmlApi) {
+        const safeApi = ctx.cmlApi.replace(/[^a-zA-Z0-9_-]/g, '_');
+        const recordUpdateFile = await this.writeRecordUpdateFile([], [], ctx.cmlApi, safeApi, workspaceDir);
+        return { cmlFile: '', associationsFile: '', ruleKeyMapping: [], recordUpdateFile };
+      }
       return { cmlFile: '', associationsFile: '', ruleKeyMapping: [] };
     }
 
     const ruleDefs = this.parseAllRecords(records);
-    const productIdToCode = await this.resolveProductCodes(conn, ruleDefs);
+    const { productIdToCode, productIdToName } = await this.resolveProductCodes(conn, ruleDefs);
 
     const api = ctx.cmlApi ?? (await this.discoverCmlApi(conn, ruleDefs, productIdToCode));
     const safeApi = api.replace(/[^a-zA-Z0-9_-]/g, '_');
@@ -108,15 +136,14 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
       productIdToCode,
       this.keyPrefix,
       this.constraintLabel,
-      this.ruleType
+      this.ruleType,
+      productIdToName
     );
     ruleKeyMapping.forEach((m) => this.log(`  -> ${m.name} => ${m.ruleKey}`));
 
-    if (ctx.updateRecords) {
-      await this.updateOrgRecords(records, ruleKeyMapping, conn);
-    }
+    const recordUpdateFile = await this.writeRecordUpdateFile(records, ruleKeyMapping, api, safeApi, workspaceDir);
 
-    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api);
+    return this.writeOutputFiles(cmlModel, ruleKeyMapping, safeApi, workspaceDir, api, recordUpdateFile);
   }
 
   /**
@@ -148,11 +175,16 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     ruleKeyMapping: RuleKeyEntry[],
     safeApi: string,
     workspaceDir: string,
-    api: string
+    api: string,
+    recordUpdateFile: string
   ): Promise<InsuranceRuleConvertResult> {
-    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
-    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
-    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+    // [Fix #15] Use path.join so emitted paths use the OS-native separator. Hardcoded '/' template
+    // literals produced forward-slash paths on Windows; tests that assert against path.join then
+    // diverged at the separator (`\` vs `/`). path.join keeps Linux unchanged ('/' verbatim) and
+    // emits backslashes on Windows, matching the test's normalized expectation.
+    const cmlPath = path.join(workspaceDir, `${safeApi}.cml`);
+    const associationsPath = path.join(workspaceDir, `${safeApi}_Associations.csv`);
+    const mappingPath = path.join(workspaceDir, `${safeApi}_RuleKeyMapping.json`);
 
     await fs.writeFile(cmlPath, mergedCml, 'utf8');
     await fs.writeFile(associationsPath, `${ASSOCIATIONS_CSV_HEADER}\n`, 'utf8');
@@ -161,20 +193,73 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     this.log(`\nMerged CML written to: ${cmlPath}`);
     this.log(`Associations (header-only, no new type associations) written to: ${associationsPath}`);
     this.log(`Rule key mapping written to: ${mappingPath}`);
-    this.log('\nNext steps:');
-    this.log('  1. Review the merged .cml file (diff against the org model)');
+    this.log(`Record update file written to: ${recordUpdateFile}`);
+    this.log('\nNext steps (this command wrote nothing to the org):');
+    this.log('  1. Review the merged .cml file (diff against the org model) and the record update file');
     this.log(
-      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+      `  2. Activate the CML: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
     );
+    this.log(`  3. Apply the org-record changes enumerated in ${recordUpdateFile} to the target org`);
 
-    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping, recordUpdateFile };
+  }
+
+  /**
+   * Build the record-update plan envelope and write it to `<safeApi>_<kind>Update.json`. This is the
+   * ONLY way org-record changes leave convert now — convert never writes to the org itself. The file
+   * is a reviewable manifest the operator applies to the org separately; this plugin does not apply it.
+   */
+  protected async writeRecordUpdateFile(
+    records: R[],
+    ruleKeyMapping: RuleKeyEntry[],
+    api: string,
+    safeApi: string,
+    workspaceDir: string
+  ): Promise<string> {
+    const plan: RecordUpdatePlan = {
+      schemaVersion: 1,
+      kind: this.recordUpdateKind,
+      cmlApi: api,
+      generatedAt: new Date().toISOString(),
+      updates: this.buildRecordUpdates(records, ruleKeyMapping),
+    };
+    // [Fix #15] path.join for cross-platform path separators (was hardcoded '/'). Note: this local
+    // is intentionally named `filePath` rather than `path` to avoid shadowing the `path` module import.
+    const filePath = path.join(workspaceDir, `${safeApi}_${RECORD_UPDATE_FILE_SUFFIX[this.recordUpdateKind]}.json`);
+    await fs.writeFile(filePath, JSON.stringify(plan, null, 2), 'utf8');
+    return filePath;
   }
 
   private async loadRecords(conn: Connection, inputFile: string | undefined): Promise<R[]> {
     if (inputFile) {
       this.log(`Reading ${this.recordLabel} records from file: ${inputFile}`);
       const contents = await fs.readFile(inputFile, 'utf8');
-      return JSON.parse(contents) as R[];
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(contents);
+      } catch (e) {
+        throw new Error(`${inputFile}: not valid JSON (${(e as Error).message})`);
+      }
+      // [Fix #6] The file is operator-supplied input that drives ProductPath splits, SOQL id
+      // resolution, and rule-key derivation. A non-array root, or records with missing/non-string
+      // Id / Name / ProductPath, would otherwise propagate `undefined`s through the pipeline and
+      // surface as confusing downstream failures (or silently malformed output). Refuse upfront.
+      if (!Array.isArray(parsed)) {
+        throw new Error(`${inputFile}: expected a top-level JSON array of ${this.recordLabel} records`);
+      }
+      parsed.forEach((entry, index) => {
+        if (entry === null || typeof entry !== 'object') {
+          throw new Error(`${inputFile}: record #${index} is not an object`);
+        }
+        const rec = entry as Record<string, unknown>;
+        for (const field of ['Id', 'Name', 'ProductPath'] as const) {
+          const value = rec[field];
+          if (typeof value !== 'string' || value.length === 0) {
+            throw new Error(`${inputFile}: record #${index} has missing or non-string ${field}`);
+          }
+        }
+      });
+      return parsed as R[];
     }
 
     this.log(`Querying ${this.recordLabel} records from org...`);
@@ -202,13 +287,14 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
   private async resolveProductCodes(
     conn: Connection,
     ruleDefs: Array<{ record: RuleRecord }>
-  ): Promise<Map<string, string>> {
+  ): Promise<{ productIdToCode: Map<string, string>; productIdToName: Map<string, string> }> {
     // Collect EVERY ProductPath segment, not just the root: merge mode needs the code of each
     // segment to build the platform-compatible pathed rule key, and the leaf segment's code to
     // resolve its CML type. The non-merge path only reads the root code, so this is a superset.
     const productIds = collectAllProductIds(ruleDefs);
+    const productIdToName = new Map<string, string>();
     try {
-      return await fetchProductCodes(conn, productIds, {
+      const productIdToCode = await fetchProductCodes(conn, productIds, {
         // M2: a blank ProductCode forces a Name/Id fallback, so the pathed rule key is derived from a
         // non-authoritative field and will NOT match the platform-generated RuleKey — the surcharge
         // then imports cleanly but silently never fires. Surface it instead of substituting silently.
@@ -216,10 +302,66 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
           this.warn(
             `Product ${productId} has no ProductCode; rule key derived from Name/Id and may not match the platform-generated RuleKey (surcharge may silently not fire)`
           ),
+        // Capture Names so convert can emit them as the Type association reference value — the field
+        // the common importer resolves the Product2 by. Validated below before they reach the model.
+        collectNames: productIdToName,
       });
+      // [Fix #8] An id we ASKED Product2 about and got nothing back for is distinct from a found
+      // product with a null ProductCode (which `onFallback` already covers). Missing-from-result
+      // ids mean the Product2 row is invalid / deleted / outside the visible scope — generation
+      // will silently fall back to the raw Id for that path segment, again yielding a non-matching
+      // platform RuleKey. Surface this case explicitly so the operator can investigate.
+      for (const id of productIds) {
+        if (!productIdToCode.has(id)) {
+          this.warn(
+            `Product ${id} was not returned by Product2 query (not found, not visible, or filtered out); ` +
+              'rule key for paths through this product will fall back to the raw Id and may not match the platform-generated RuleKey'
+          );
+        }
+      }
+      this.validateAssociationNames(productIdToName);
+      return { productIdToCode, productIdToName };
     } catch (e) {
       this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
-      return new Map<string, string>();
+      return { productIdToCode: new Map<string, string>(), productIdToName: new Map<string, string>() };
+    }
+  }
+
+  /**
+   * Validates the Id -> Name map that feeds each Type association's reference value, mutating it in
+   * place so only safe, importer-resolvable Names survive. The Name is written into the naive
+   * comma-joined associations CSV and, downstream, into the common importer's single-quoted SOQL
+   * `WHERE Name IN ('<Name>')`. Two hazards, neither of which we can fix in the (Rev-Cloud-owned)
+   * importer. Unsafe characters (comma, quote, backslash, newline) corrupt the CSV column or break
+   * out of the SOQL literal — such a Name is dropped from the map (the generator falls back to the
+   * ProductCode) and warned, so the association may not resolve but the output stays valid and
+   * injection-free instead of silently wrong. Duplicate Names across distinct product ids make the
+   * importer's by-Name lookup ambiguous (last-writer-wins), so a Type could bind to the wrong
+   * Product2 — we warn but keep the entries; the documented precondition is that Product Name is
+   * unique per migration scope.
+   */
+  private validateAssociationNames(productIdToName: Map<string, string>): void {
+    const nameToIds = new Map<string, string[]>();
+    for (const [productId, name] of productIdToName) {
+      if (!isSafeAssociationReferenceValue(name)) {
+        this.warn(
+          `Product ${productId} Name "${name}" contains characters unsafe for the associations CSV / import SOQL; ` +
+            'falling back to ProductCode for its Type association (the association may not resolve on import)'
+        );
+        productIdToName.delete(productId);
+        continue;
+      }
+      const ids = nameToIds.get(name) ?? [];
+      ids.push(productId);
+      nameToIds.set(name, ids);
+    }
+    for (const [name, ids] of nameToIds) {
+      if (ids.length > 1) {
+        this.warn(
+          `Product Name "${name}" is shared by ${ids.length} products (${ids.join(', ')}); ` +
+            'the import resolves Type associations by Name, so bindings may be ambiguous. Product Name must be unique.'
+        );
+      }
     }
   }
 
@@ -239,7 +381,11 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
       this.warn(`CML auto-discovery failed: ${(e as Error).message}`);
     }
 
-    const codes = Array.from(productIds).map((id) => productIdToCode.get(id) ?? id);
+    // [Fix #5] The fallback API name is downstream written to disk as `<safeApi>.cml` and used in
+    // SOQL/log lines. Raw ProductCodes can contain spaces, slashes, quotes, or other characters
+    // that break path/SOQL semantics; sanitize each segment to the same `[A-Za-z0-9_]` alphabet
+    // the rest of the generator uses so the generated name is injection-/path-traversal-safe.
+    const codes = Array.from(productIds).map((id) => sanitizeName(productIdToCode.get(id) ?? id));
     const generated = `${this.apiNamePrefix}${codes.join('_')}`;
     this.log(`No existing CML found. Generated new CML API name: ${generated}`);
     return generated;
@@ -250,11 +396,15 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     ruleKeyMapping: RuleKeyEntry[],
     safeApi: string,
     workspaceDir: string,
-    api: string
+    api: string,
+    recordUpdateFile: string
   ): Promise<InsuranceRuleConvertResult> {
-    const cmlPath = `${workspaceDir}/${safeApi}.cml`;
-    const associationsPath = `${workspaceDir}/${safeApi}_Associations.csv`;
-    const mappingPath = `${workspaceDir}/${safeApi}_RuleKeyMapping.json`;
+    // [Fix #15] path.join for cross-platform path separators (was hardcoded '/'). See companion site
+    // in writeMergedOutputFiles — same rationale: Windows-unit-tests assert against path.join, and
+    // forward-slash literals broke the equality there.
+    const cmlPath = path.join(workspaceDir, `${safeApi}.cml`);
+    const associationsPath = path.join(workspaceDir, `${safeApi}_Associations.csv`);
+    const mappingPath = path.join(workspaceDir, `${safeApi}_RuleKeyMapping.json`);
 
     await fs.writeFile(cmlPath, cmlModel.generateCml(), 'utf8');
     await fs.writeFile(associationsPath, generateCsvForAssociations(safeApi, cmlModel.associations), 'utf8');
@@ -263,28 +413,33 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     this.log(`\nCML written to: ${cmlPath}`);
     this.log(`Associations written to: ${associationsPath}`);
     this.log(`Rule key mapping written to: ${mappingPath}`);
+    this.log(`Record update file written to: ${recordUpdateFile}`);
     this.log(`\nConverted ${ruleKeyMapping.length} ${this.recordLabel} rules to CML`);
-    this.log('\nNext steps:');
-    this.log('  1. Review the generated .cml file');
+    this.log('\nNext steps (this command wrote nothing to the org):');
+    this.log('  1. Review the generated .cml file and the record update file');
     this.log(
-      `  2. Import: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
+      `  2. Activate the CML: sf cml import as-expression-set --cml-api ${api} --context-definition <CD_NAME> --target-org <org>`
     );
-    this.log('  3. Update records with RuleKey from mapping file');
+    this.log(`  3. Apply the org-record changes enumerated in ${recordUpdateFile} to the target org`);
 
-    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping };
+    return { cmlFile: cmlPath, associationsFile: associationsPath, ruleKeyMapping, recordUpdateFile };
   }
 
   protected abstract parseRecord(record: R): ParsedRuleDefinition | null;
-  protected abstract updateOrgRecords(records: R[], ruleKeyMapping: RuleKeyEntry[], conn: Connection): Promise<void>;
+
+  /**
+   * Pure transform: given the parsed records and the rule-key mapping, return the list of org-record
+   * changes convert WOULD have made. No org writes — the result is serialized into the update file.
+   */
+  protected abstract buildRecordUpdates(records: R[], ruleKeyMapping: RuleKeyEntry[]): RecordUpdate[];
 }
 
 function collectAllProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<string> {
   const productIds = new Set<string>();
   for (const { record } of ruleDefs) {
-    for (const segment of record.ProductPath.split('/')) {
-      const id = segment.trim();
-      if (id) productIds.add(id);
-    }
+    // [Fix #11] One canonical split helper so trim + drop-empty semantics never diverge from the
+    // merge module's parsing.
+    for (const id of splitProductPath(record.ProductPath)) productIds.add(id);
   }
   return productIds;
 }
@@ -294,7 +449,9 @@ function collectAllProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<stri
 function collectRootProductIds(ruleDefs: Array<{ record: RuleRecord }>): Set<string> {
   const productIds = new Set<string>();
   for (const { record } of ruleDefs) {
-    const root = record.ProductPath.split('/')[0]?.trim();
+    // [Fix #11] splitProductPath already trims and drops empty segments, so the root is the first
+    // emitted id (or undefined when the entire path is blank).
+    const root = splitProductPath(record.ProductPath)[0];
     if (root) productIds.add(root);
   }
   return productIds;

--- a/src/shared/insurance/insurance-rule-convert-command.ts
+++ b/src/shared/insurance/insurance-rule-convert-command.ts
@@ -208,7 +208,15 @@ export abstract class InsuranceRuleConvertCommand<R extends RuleRecord> extends 
     // resolve its CML type. The non-merge path only reads the root code, so this is a superset.
     const productIds = collectAllProductIds(ruleDefs);
     try {
-      return await fetchProductCodes(conn, productIds);
+      return await fetchProductCodes(conn, productIds, {
+        // M2: a blank ProductCode forces a Name/Id fallback, so the pathed rule key is derived from a
+        // non-authoritative field and will NOT match the platform-generated RuleKey — the surcharge
+        // then imports cleanly but silently never fires. Surface it instead of substituting silently.
+        onFallback: (productId) =>
+          this.warn(
+            `Product ${productId} has no ProductCode; rule key derived from Name/Id and may not match the platform-generated RuleKey (surcharge may silently not fire)`
+          ),
+      });
     } catch (e) {
       this.warn(`Could not fetch product codes: ${(e as Error).message}. Using product IDs instead.`);
       return new Map<string, string>();

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -78,18 +78,57 @@ export function generateRuleKey(
   return parts.join('__');
 }
 
-// Operators whose RHS the shared emitter interpolates UNQUOTED (e.g. `attr > 2020`). Insurance
-// data for these is always numeric, so we require a safe numeric literal here — a malformed or
-// hostile value (e.g. `2020) || evil(`) can otherwise reach the curated model verbatim.
-const UNQUOTED_RELATIONAL_OPERATORS: ReadonlySet<string> = new Set([
+// Relational operators (<, <=, >, >=) ALWAYS interpolate their RHS unquoted, regardless of
+// dataType. Equals/NotEquals interpolate unquoted whenever the resolved cmlDataType is NOT
+// CML_DATA_TYPES.STRING (the shared emitter only quotes when dataType === 'string'). Either way an
+// unquoted, attacker-influenced value (e.g. `2020) || evil(`) would reach the curated model
+// verbatim, so every value on an unquoted-emission condition must be a bare safe literal.
+const ALWAYS_UNQUOTED_OPERATORS: ReadonlySet<string> = new Set([
   'LessThan',
   'LessThanOrEquals',
   'GreaterThan',
   'GreaterThanOrEquals',
 ]);
 
+// Operators that emit a value via doubleQuotedIfNeeded — unquoted unless cmlDataType === STRING.
+const VALUE_EQUALITY_OPERATORS: ReadonlySet<string> = new Set(['Equals', 'NotEquals']);
+
 function isSafeNumericLiteral(value: string): boolean {
   return /^-?\d+(\.\d+)?$/.test(value.trim());
+}
+
+function isSafeBooleanLiteral(value: string): boolean {
+  return /^(true|false)$/.test(value.trim());
+}
+
+// Bare date / datetime literal: YYYY-MM-DD optionally followed by an ISO-8601 time component. No
+// parens, operators, or whitespace that could break out of the unquoted slot.
+function isSafeDateLiteral(value: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?$/.test(value.trim());
+}
+
+// A value is safe to emit unquoted only if it is a bare literal of the target CML type. Anything
+// that isn't (including strings, which must never reach an unquoted slot) is rejected.
+function isSafeUnquotedLiteral(value: string, cmlDataType: string): boolean {
+  switch (cmlDataType) {
+    case CML_DATA_TYPES.INTEGER:
+    case CML_DATA_TYPES.DECIMAL:
+      return isSafeNumericLiteral(value);
+    case CML_DATA_TYPES.BOOLEAN:
+      return isSafeBooleanLiteral(value);
+    case CML_DATA_TYPES.DATE:
+      return isSafeDateLiteral(value);
+    default:
+      return false;
+  }
+}
+
+// A value destined for a string-quoted slot must be safely single-line quotable. The shared
+// escapeQuotes escapes ' and " but NOT backslash, so a value containing a backslash (e.g. ending
+// in `\`, or a `\"` sequence) can escape its own closing quote and break out into raw CML. Reject
+// any backslash, plus newlines that would split the single-line literal.
+function isSafeQuotableString(value: string): boolean {
+  return !/[\\\r\n]/.test(value);
 }
 
 function buildConditionExpression(condition: RuleCondition): string | null {
@@ -100,15 +139,27 @@ function buildConditionExpression(condition: RuleCondition): string | null {
     return null;
   }
 
-  // Relational operators emit their RHS unquoted; only safe numeric literals are allowed through
-  // so the value cannot inject CML or produce a type-unsafe comparison. A failing value drops the
-  // condition (the caller filters nulls), exactly as an unknown operator or a missing value does.
-  if (UNQUOTED_RELATIONAL_OPERATORS.has(op) && !(condition.values ?? []).every(isSafeNumericLiteral)) {
+  const values = condition.values ?? [];
+  const cmlDataType = dataTypeToCml(condition.dataType);
+
+  // Determine whether this operator/dataType pair emits its RHS UNQUOTED. Relational operators
+  // always do; Equals/NotEquals do whenever the cmlDataType is not STRING. On the unquoted path we
+  // require every value to be a bare safe literal; otherwise the value would land in the curated
+  // model verbatim and could inject CML or produce a type-unsafe comparison. A failing value drops
+  // the condition (the caller filters nulls), exactly as an unknown operator or missing value does.
+  const emitsUnquoted =
+    ALWAYS_UNQUOTED_OPERATORS.has(op) || (VALUE_EQUALITY_OPERATORS.has(op) && cmlDataType !== CML_DATA_TYPES.STRING);
+
+  if (emitsUnquoted) {
+    if (!values.every((v) => isSafeUnquotedLiteral(v, cmlDataType))) {
+      return null;
+    }
+  } else if (!values.every(isSafeQuotableString)) {
+    // String-quoted path: reject values the shared escaper cannot safely contain (backslash, etc.).
     return null;
   }
 
   const attrName = sanitizeName(condition.attributeName ?? condition.contextTagName ?? 'unknown');
-  const cmlDataType = dataTypeToCml(condition.dataType);
   return convertToCmlExpression(attrName, op, condition.values, cmlDataType);
 }
 
@@ -150,6 +201,61 @@ export function collectAttributes(ruleDefs: Array<{ ruleDef: { ruleCriteria?: Ru
   return attrs;
 }
 
+/**
+ * Collects only the attributes that actually reach the emitted CML — i.e. those on conditions whose
+ * `buildConditionExpression` returned a non-null expression. Conditions dropped by the safe-literal
+ * guard, an unknown operator, or missing values do NOT contribute their attribute. This is the
+ * companion to `collectAttributes` for merge-mode attribute-presence warnings: warning about an
+ * attribute the declaration never emitted (because the guard dropped its condition) is spurious
+ * noise on exactly the inputs the guard sanitized. Unlike `collectAttributes`, names are returned
+ * sanitized to match how they appear in the emitted declaration.
+ */
+export function collectEmittedAttributes(ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>): Set<string> {
+  const attrs = new Set<string>();
+  for (const { ruleDef } of ruleDefs) {
+    for (const criteria of ruleDef.ruleCriteria ?? []) {
+      for (const cond of criteria.conditions ?? []) {
+        if (buildConditionExpression(cond) === null) continue;
+        const name = cond.attributeName ?? cond.contextTagName;
+        if (name) attrs.add(sanitizeName(name));
+      }
+    }
+  }
+  return attrs;
+}
+
+/**
+ * Derives the real CML data type for each collected attribute from its condition `dataType`.
+ * When an attribute appears with more than one distinct CML type (a conflict), or its type is
+ * unknown, it falls back to STRING. Returned alongside (not replacing) the Set from
+ * collectAttributes, which merge mode still depends on.
+ */
+export function collectAttributeTypes(
+  ruleDefs: Array<{ ruleDef: { ruleCriteria?: RuleCriteria[] } }>
+): Map<string, string> {
+  const types = new Map<string, string>();
+  const conflicting = new Set<string>();
+  for (const { ruleDef } of ruleDefs) {
+    for (const criteria of ruleDef.ruleCriteria ?? []) {
+      for (const cond of criteria.conditions ?? []) {
+        const name = cond.attributeName ?? cond.contextTagName;
+        if (!name) continue;
+        const cmlType = dataTypeToCml(cond.dataType);
+        const existing = types.get(name);
+        if (existing === undefined) {
+          types.set(name, cmlType);
+        } else if (existing !== cmlType) {
+          conflicting.add(name);
+        }
+      }
+    }
+  }
+  for (const name of conflicting) {
+    types.set(name, CML_DATA_TYPES.STRING);
+  }
+  return types;
+}
+
 export function buildCmlModel(
   ruleDefs: Array<{ record: RuleRecord; ruleDef: ParsedRuleDefinition }>,
   productIdToCode: Map<string, string>,
@@ -184,8 +290,10 @@ export function buildCmlModel(
     const productType = new CmlType(typeName, undefined, undefined);
 
     const attrs = collectAttributes(productRules);
+    const attrTypes = collectAttributeTypes(productRules);
     for (const attrName of attrs) {
-      productType.addAttribute(new CmlAttribute(null, sanitizeName(attrName), CML_DATA_TYPES.STRING));
+      const cmlType = attrTypes.get(attrName) ?? CML_DATA_TYPES.STRING;
+      productType.addAttribute(new CmlAttribute(null, sanitizeName(attrName), cmlType));
     }
 
     for (const { record, ruleDef } of productRules) {

--- a/src/shared/insurance/insurance-rule-generator.ts
+++ b/src/shared/insurance/insurance-rule-generator.ts
@@ -131,6 +131,22 @@ function isSafeQuotableString(value: string): boolean {
   return !/[\\\r\n]/.test(value);
 }
 
+/**
+ * Whether a product Name is safe to emit as a Type association's reference value
+ * (`$Product2ReferenceId`). That value travels two unescaped hops we do NOT own and cannot change:
+ * the naive comma-joined `_Associations.csv` column (a comma shifts every later column), and the
+ * common `cml import as-expression-set` resolver's single-quoted SOQL `WHERE Name IN ('<value>')`
+ * (a single quote breaks out of the literal; a backslash or newline corrupts the row).
+ * A Name failing this guard is dropped by the convert layer (it falls back to the ProductCode and
+ * warns) rather than silently producing a corrupt CSV / injecting SOQL. An empty / whitespace-only
+ * Name is also rejected — it can never match a real Product2 by name. Mirrors the reject-don't-escape
+ * stance of {@link isSafeQuotableString} for condition values.
+ */
+export function isSafeAssociationReferenceValue(value: string): boolean {
+  if (value.trim().length === 0) return false;
+  return !/[,'"\\\r\n]/.test(value);
+}
+
 function buildConditionExpression(condition: RuleCondition): string | null {
   if (!isKnownOperator(condition.operator)) return null;
 
@@ -264,7 +280,14 @@ export function buildCmlModel(
   // When set, eligibility is emitted as a CML `rule(decl, "<ruleType>", "<ruleKey>", "True")`
   // statement instead of a `constraint NAME = (decl, "label");`. Surcharge passes
   // 'InsuranceSurchargeRule'; underwriting leaves it undefined to keep the constraint form.
-  ruleType?: string
+  ruleType?: string,
+  // Maps a root product id to its Product2 Name. The common `cml import as-expression-set` resolves
+  // each Type association's Product2 by NAME (`WHERE Name IN (<$Product2ReferenceId>)`), so the Name
+  // — not the ProductCode — must land in the association reference value or the importer silently
+  // drops the binding. Optional + last so the legacy (code-as-reference) call sites stay valid; the
+  // convert layer supplies only Names that passed isSafeAssociationReferenceValue, hence the
+  // unconditional ProductCode fallback below for any product missing a safe Name.
+  productIdToName?: Map<string, string>
 ): { cmlModel: CmlModel; ruleKeyMapping: RuleKeyEntry[] } {
   const cmlModel = new CmlModel();
 
@@ -314,8 +337,12 @@ export function buildCmlModel(
     }
 
     cmlModel.addType(productType);
+    // tag/type name stay ProductCode-derived (the CML doc keys off them); only the reference value
+    // — what the common importer resolves the Product2 by — becomes the Name. Fall back to the
+    // ProductCode when no safe Name was supplied (preserves legacy behavior for code-only callers).
+    const referenceValue = productIdToName?.get(rootProductId) ?? productCode;
     cmlModel.addAssociation(
-      new Association(null, typeName, ASSOCIATION_TYPES.TYPE, rootProductId, 'Product2', productCode)
+      new Association(null, typeName, ASSOCIATION_TYPES.TYPE, rootProductId, 'Product2', referenceValue)
     );
   }
 

--- a/src/shared/insurance/models.ts
+++ b/src/shared/insurance/models.ts
@@ -62,3 +62,58 @@ export type RuleKeyEntry = {
   name: string;
   ruleKey: string;
 };
+
+// ---------------------------------------------------------------------------
+// Record-update export artifacts (classes (b) UW update, (c) surcharge update).
+//
+// Convert is file-only: instead of mutating the org live, it serializes the
+// exact org-record changes it used to apply into a reviewable/correctable
+// `<safeApi>_{Underwriting,Surcharge}Update.json` manifest. The operator
+// reviews that file and applies its changes to the org separately — this
+// plugin emits the manifest but does not apply it. See
+// docs/insurance-export-review-import-redesign.md §3.
+// ---------------------------------------------------------------------------
+
+export type RecordUpdateField = {
+  /** sObject field API name to set, e.g. 'RuleEngineType' or 'DynamicRuleDefinition'. */
+  field: string;
+  /** Value to write. JSON-blob fields (DynamicRuleDefinition) are stringified verbatim. */
+  value: string;
+};
+
+export type RecordUpdate = {
+  sobject: 'UnderwritingRuleGroup' | 'UnderwritingRule' | 'ProductSurcharge';
+  /** 15/18-char Salesforce Id (re-validated on apply). */
+  id: string;
+  // Record Name -- REQUIRED. [Fix #14] This is ADVISORY context for the operator/apply tool, not
+  // an enforced check by this plugin. Convert is file-only and does NOT write to the org; whether
+  // Name is actually cross-checked against the org as an identity guard is the responsibility of
+  // whichever apply tool consumes this manifest.
+  name: string;
+  // UnderwritingRule only: the rule ApiName. [Fix #14] Same status as `name` -- ADVISORY context
+  // for the apply tool; whether it functions as a second identity guard alongside Name is up to
+  // that tool, not this plugin.
+  apiName?: string;
+  fields: RecordUpdateField[];
+  // Surcharge only: the convert-computed pathed rule key the CML `rule(...)` was emitted under.
+  // [Fix #14] ADVISORY -- meant as a verification key for an apply tool. NOT written to the org
+  // (the platform auto-generates ProductSurcharge.RuleKey when RuleEngineType flips); a mismatch
+  // is what an apply tool MAY use to detect that the surcharge will silently not fire. This
+  // plugin emits it but does not consume it.
+  expectedRuleKey?: string;
+  // Surcharge only: source ProductCodes (ordered ProductPath segments) at convert time. [Fix #14]
+  // ADVISORY drift-detection input -- an apply tool consuming this manifest MAY compare against
+  // the org's current ProductCodes to flag ProductCode/ProductPath drift that would desync the
+  // platform-generated RuleKey. This plugin does not perform that comparison itself.
+  productCodes?: string[];
+};
+
+export type RecordUpdatePlan = {
+  schemaVersion: 1;
+  kind: 'underwriting-update' | 'surcharge-update';
+  /** Raw CML api name (matches the .cml / RuleKeyMapping for traceability). */
+  cmlApi: string;
+  /** ISO timestamp, advisory (drift-detection aid). */
+  generatedAt: string;
+  updates: RecordUpdate[];
+};

--- a/test/commands/cml/convert/surcharge-rules.test.ts
+++ b/test/commands/cml/convert/surcharge-rules.test.ts
@@ -132,6 +132,24 @@ describe('cml convert surcharge-rules', () => {
     return result;
   };
 
+  const runCommandNoCmlApi = async (): Promise<CmlConvertSurchargeRulesResult> => {
+    const result: CmlConvertSurchargeRulesResult = await CmlConvertSurchargeRules.run([
+      '--target-org',
+      testOrg.username,
+      '--surcharge-file',
+      surchargeFile,
+      '--workspace-dir',
+      workspaceDir,
+    ]);
+    return result;
+  };
+
+  const logOutput = (): string =>
+    sfCommandStubs.log
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+
   const warnOutput = (): string =>
     sfCommandStubs.warn
       .getCalls()
@@ -266,6 +284,225 @@ describe('cml convert surcharge-rules', () => {
     const mergedCml = await fs.readFile(result.cmlFile, 'utf8');
     expect(mergedCml).to.include('SC__autoSilver__collision__GhostAttrFee');
     expect(mergedCml).to.not.include('OrphanFee');
+  });
+
+  // ---- Fix #15: every emitted output path must use the OS-native separator (path.join), not
+  // a hardcoded `${workspaceDir}/<name>` template literal. The hardcoded form returns forward
+  // slashes on Windows even when `workspaceDir` is `C:\Users\...`, which yields paths like
+  // `C:\Users\foo/Auto_Silver.cml` and breaks any caller that compares with path.join(). This
+  // test verifies the four output paths (cml, associations, mapping, record-update) all match
+  // path.join(workspaceDir, ...) exactly and contain no mixed separators within their leaf names.
+  it('Fix #15: emits output paths via path.join so the OS-native separator is used', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tCOLL00000000001', ProductCode: 'collision', Name: 'Collision' },
+        ],
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    const result = await runCommand();
+
+    // Every emitted path equals path.join(workspaceDir, leaf) — i.e. uses the OS-native separator.
+    // On Linux/macOS path.sep is '/', on Windows '\'. The test is meaningful on every platform
+    // because a hardcoded '${workspaceDir}/<name>' template literal would only ever emit '/',
+    // which on Windows differs from path.join and would fail this assertion.
+    expect(result.cmlFile).to.equal(path.join(workspaceDir, `${CML_API}.cml`));
+    expect(result.associationsFile).to.equal(path.join(workspaceDir, `${CML_API}_Associations.csv`));
+    // recordUpdateFile is typed as optional on the result envelope (it's absent for build-mode
+    // failures that short-circuit before the manifest is written), but the merge path always
+    // produces it — assert presence then equality.
+    expect(result.recordUpdateFile, 'merge path should emit a record-update file').to.be.a('string');
+    expect(result.recordUpdateFile).to.equal(path.join(workspaceDir, `${CML_API}_SurchargeUpdate.json`));
+
+    // The leaf name of each path must be plain (no embedded separators). Defends against a future
+    // regression where someone reintroduces `${workspaceDir}/${leaf}` and `leaf` itself accidentally
+    // contains a slash — path.basename should be a clean filename, not a sub-path.
+    expect(path.basename(result.cmlFile)).to.equal(`${CML_API}.cml`);
+    expect(path.basename(result.recordUpdateFile as string)).to.equal(`${CML_API}_SurchargeUpdate.json`);
+  });
+
+  // ---- Fix #11: the convert layer routes every ProductPath parse through `splitProductPath` —
+  // a single helper with `trim + drop-empty` semantics. A path with leading slashes, blank
+  // segments, and surrounding whitespace must NOT produce ghost product ids (which would surface
+  // as bogus "Product ... was not returned by Product2 query" warnings for the empty string).
+  it('Fix #11: messy ProductPaths (leading slash, blanks, whitespace) do not generate ghost product ids', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tCOLL00000000001', ProductCode: 'collision', Name: 'Collision' },
+        ],
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        // Leading slash, surrounding whitespace, and a blank middle segment — these would yield
+        // empty-string ids if the convert layer parsed the path with raw `.split('/')`.
+        ProductPath: '/  01tROOT00000000001  // 01tCOLL00000000001 /',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    await runCommand();
+
+    const warns = warnOutput();
+    // No warning naming the empty string as a product id.
+    expect(warns).to.not.match(/Product\s+was not returned/);
+    expect(warns).to.not.match(/Product\s+has no ProductCode/);
+  });
+
+  // ---- Fix #9: when any rule is skipped the merge logs a single high-signal summary line that
+  // buckets the skip reasons. An operator scanning the output for "what got dropped" should not
+  // have to grep through per-rule warnings to count reasons.
+  it('Fix #9: logs a final skip-breakdown summary when at least one rule is skipped', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tORPH00000000001', ProductCode: 'orphan', Name: 'Orphan' },
+        ],
+        // No tag for the leaf => no-type-tag skip.
+        productTypeTags: [],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Orphan Fee',
+        ProductPath: '01tROOT00000000001/01tORPH00000000001',
+        RuleDefinition: ruleDefinition('OrphanFee', []),
+      },
+    ]);
+
+    await runCommand();
+
+    const logs = logOutput();
+    expect(logs).to.match(/Skip breakdown:/);
+    expect(logs).to.match(/no-type-tag/);
+  });
+
+  // ---- Fix #8: a product id that the Product2 query did NOT return (deleted / not visible /
+  // filtered) used to silently fall back to the raw Id for that path segment, yielding a rule
+  // key that won't match the platform-generated RuleKey. Surface it as a warning, distinct from
+  // the existing null-ProductCode fallback warning.
+  it('Fix #8: warns for a product id that is absent from the Product2 query result map', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        // Only the root resolves; the leaf id is referenced by ProductPath but missing from the
+        // Product2 fixture, so it never reaches productIdToCode.
+        productCodes: [{ Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' }],
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    await runCommand();
+
+    const warns = warnOutput();
+    // The Fix #8 warning specifically calls out the missing leaf id.
+    expect(warns).to.match(/01tCOLL00000000001 was not returned by Product2 query/);
+  });
+
+  // ---- Fix #6: the --surcharge-file path JSON-parses operator-supplied input. A non-array root
+  // or a record missing Id / Name / ProductPath used to propagate `undefined`s downstream as
+  // confusing errors / malformed output; the loader now refuses such input with a clear message.
+  it('Fix #6: rejects --surcharge-file whose top-level JSON is not an array', async () => {
+    stubOrgConnection({ existingCml: GOLD_CML });
+    // Top-level object instead of an array of records.
+    await fs.writeFile(surchargeFile, JSON.stringify({ records: [] }), 'utf8');
+
+    let error: Error | undefined;
+    try {
+      await runCommand();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error, 'command should reject a non-array root').to.be.an('error');
+    expect(error?.message).to.match(/expected a top-level JSON array/);
+  });
+
+  it('Fix #6: rejects --surcharge-file records that are missing required string fields', async () => {
+    stubOrgConnection({ existingCml: GOLD_CML });
+    // Valid array shape but Id is the wrong type.
+    await fs.writeFile(
+      surchargeFile,
+      JSON.stringify([{ Id: 12345, Name: 'X', ProductPath: '01tROOT00000000001', RuleDefinition: null }]),
+      'utf8'
+    );
+
+    let error: Error | undefined;
+    try {
+      await runCommand();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error, 'command should reject a non-string Id').to.be.an('error');
+    expect(error?.message).to.match(/missing or non-string Id/);
+  });
+
+  // ---- Fix #5: when --cml-api is omitted, the auto-discovery fallback generates a CML API name
+  // from the joined ProductCodes. A ProductCode that contains slashes / spaces / quotes would break
+  // the on-disk path or SOQL identifier semantics downstream; the fallback must sanitize each
+  // segment to `[A-Za-z0-9_]` before joining (mirroring sanitizeName).
+  it('Fix #5: sanitizes ProductCode segments in the generated fallback CML API name', async () => {
+    // No existing ConstraintModel and no discovered API — the command will reach the generated-name
+    // fallback path inside discoverCmlApi, log it, then later error because no model exists. We
+    // assert on the LOGGED fallback name, which is what would otherwise become the file name.
+    stubOrgConnection({
+      existingCml: undefined,
+      productCodes: [
+        // A ProductCode with characters that would corrupt the generated file path / SOQL identifier
+        // if pasted in verbatim — Fix #5 sanitizes them to underscores before joining.
+        { Id: '01tROOT00000000001', ProductCode: 'auto/silver "v1"', Name: null },
+      ],
+      productTypeTags: [],
+    });
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    try {
+      await runCommandNoCmlApi();
+    } catch {
+      // The command errors after the fallback name is logged (no curated model exists). The error
+      // itself isn't what this test cares about — we assert on the fallback's log line.
+    }
+
+    const logs = logOutput();
+    // The unsafe characters from the ProductCode never reach the generated name.
+    expect(logs).to.match(/Generated new CML API name: SC_auto_silver__v1_/);
+    expect(logs).to.not.match(/Generated new CML API name:.*\//);
+    expect(logs).to.not.match(/Generated new CML API name:.*"/);
   });
 
   // ---- M8: the insurance-layer merge-CSV header MUST stay identical to the common util's header.

--- a/test/commands/cml/convert/surcharge-rules.test.ts
+++ b/test/commands/cml/convert/surcharge-rules.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { TestContext, MockTestOrgData } from '@salesforce/core/testSetup';
+import { Connection } from '@salesforce/core';
+import { expect } from 'chai';
+import { stubSfCommandUx } from '@salesforce/sf-plugins-core';
+import CmlConvertSurchargeRules, {
+  type CmlConvertSurchargeRulesResult,
+} from '../../../../src/commands/cml/convert/surcharge-rules.js';
+import { generateCsvForAssociations } from '../../../../src/shared/utils/association.utils.js';
+
+/**
+ * Curated "Gold Standard"-shaped model returned by the (mocked) ConstraintModel blob endpoint. It
+ * declares a single `Collision` leaf type with a `Limit` attribute; surcharges nest into it.
+ */
+const GOLD_CML = `
+type AutoSilver {
+    decimal(2) totalPrice;
+}
+
+type Collision {
+    int Limit = [1000, 2000, 5000];
+}
+`;
+
+const CML_API = 'Auto_Silver';
+
+/** A surcharge record as it appears in ProductSurcharge JSON (RuleDefinition is a JSON string). */
+type SurchargeFixture = {
+  Id: string;
+  Name: string;
+  ProductPath: string;
+  RuleDefinition: string | null;
+};
+
+const ruleDefinition = (apiName: string, conditions: unknown[]): string =>
+  JSON.stringify({
+    ruleApiName: apiName,
+    ruleCriteria: conditions.length ? [{ rootObjectId: 'root', conditions }] : [],
+  });
+
+type MockOpts = {
+  existingCml?: string | undefined;
+  productCodes?: Array<{ Id: string; ProductCode: string | null; Name: string | null }>;
+  productTypeTags?: Array<{ ReferenceObjectId: string; ConstraintModelTag: string }>;
+};
+
+/** Identity helper so the org-fixture options read declaratively at each call site. */
+const mockConnection = (opts: MockOpts): MockOpts => opts;
+
+describe('cml convert surcharge-rules', () => {
+  const $$ = new TestContext();
+  const testOrg = new MockTestOrgData();
+  let sfCommandStubs: ReturnType<typeof stubSfCommandUx>;
+  let workspaceDir: string;
+  let surchargeFile: string;
+
+  beforeEach(async () => {
+    sfCommandStubs = stubSfCommandUx($$.SANDBOX);
+    await $$.stubAuths(testOrg);
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'surcharge-rules-test-'));
+    surchargeFile = path.join(workspaceDir, 'surcharges.json');
+  });
+
+  afterEach(async () => {
+    $$.restore();
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Routes the connection methods the surcharge command touches to in-memory fakes, keyed off the
+   * SOQL text / blob URL. No live org, no network. `productTypeTags` controls which leaf products
+   * resolve to a CML type (no tag => the rule is skipped as UNRESOLVED).
+   */
+  const stubOrgConnection = (opts: MockOpts): void => {
+    $$.SANDBOX.stub(Connection.prototype, 'getApiVersion').returns('68.0');
+    $$.SANDBOX.stub(Connection.prototype, 'sobject').callsFake(
+      (name: string) =>
+        ({
+          findOne: (): Promise<unknown> => {
+            if (opts.existingCml === undefined) return Promise.resolve(null);
+            if (name === 'ExpressionSetDefinition') return Promise.resolve({ Id: 'def1' });
+            if (name === 'ExpressionSetDefinitionVersion') return Promise.resolve({ Id: 'ver1' });
+            return Promise.resolve(null);
+          },
+        } as unknown as ReturnType<Connection['sobject']>)
+    );
+    // TestContext already wraps Connection.prototype.request; override its fake instead of
+    // re-stubbing. The only request the command issues is the ConstraintModel blob GET.
+    $$.fakeConnectionRequest = () => Promise.resolve(opts.existingCml ?? '');
+    const queryFake = (soql: string): Promise<{ records: unknown[] }> => {
+      if (soql.includes('FROM Product2')) return Promise.resolve({ records: opts.productCodes ?? [] });
+      if (soql.includes('FROM ExpressionSetConstraintObj')) {
+        return Promise.resolve({ records: opts.productTypeTags ?? [] });
+      }
+      return Promise.resolve({ records: [] });
+    };
+    $$.SANDBOX.stub(Connection.prototype, 'query').callsFake(queryFake as never);
+  };
+
+  const writeSurchargeFile = async (records: SurchargeFixture[]): Promise<void> => {
+    await fs.writeFile(surchargeFile, JSON.stringify(records), 'utf8');
+  };
+
+  const runCommand = async (): Promise<CmlConvertSurchargeRulesResult> => {
+    const result: CmlConvertSurchargeRulesResult = await CmlConvertSurchargeRules.run([
+      '--target-org',
+      testOrg.username,
+      '--surcharge-file',
+      surchargeFile,
+      '--cml-api',
+      CML_API,
+      '--workspace-dir',
+      workspaceDir,
+    ]);
+    return result;
+  };
+
+  const warnOutput = (): string =>
+    sfCommandStubs.warn
+      .getCalls()
+      .flatMap((c) => c.args)
+      .join('\n');
+
+  it('errors clearly when no existing ConstraintModel is found (merge has nothing to merge into)', async () => {
+    // existingCml undefined => fetchExistingConstraintModel resolves undefined => the merge guard fires.
+    stubOrgConnection({
+      existingCml: undefined,
+      productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+    });
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    let error: Error | undefined;
+    try {
+      await runCommand();
+    } catch (e) {
+      error = e as Error;
+    }
+    expect(error, 'command should reject when no model exists').to.be.an('error');
+    expect(error?.message).to.match(/existing ConstraintModel/i);
+    expect(error?.message).to.include(CML_API);
+  });
+
+  it('inserts a surcharge rule into the resolved leaf type block and writes the three output files', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tCOLL00000000001', ProductCode: 'collision', Name: 'Collision' },
+        ],
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', [
+          { operator: 'GreaterThan', attributeName: 'Limit', dataType: 'Number', values: ['1000'] },
+        ]),
+      },
+    ]);
+
+    const result = await runCommand();
+
+    // Outputs are reported back and on disk.
+    expect(result.cmlFile).to.equal(path.join(workspaceDir, `${CML_API}.cml`));
+    expect(result.associationsFile).to.equal(path.join(workspaceDir, `${CML_API}_Associations.csv`));
+    expect(result.ruleKeyMapping).to.have.length(1);
+    expect(result.ruleKeyMapping[0].ruleKey).to.equal('SC__autoSilver__collision__CollisionFee');
+
+    const mergedCml = await fs.readFile(result.cmlFile, 'utf8');
+    // The rule is nested inside the Collision block (after its header, before the model end).
+    const collisionIdx = mergedCml.indexOf('type Collision {');
+    const ruleIdx = mergedCml.indexOf('SC__autoSilver__collision__CollisionFee');
+    expect(ruleIdx).to.be.greaterThan(collisionIdx);
+    expect(mergedCml).to.include(
+      'rule(Limit > 1000, "InsuranceSurchargeRule", "SC__autoSilver__collision__CollisionFee", "True");'
+    );
+
+    // The associations file is the header-only CSV.
+    const csv = await fs.readFile(result.associationsFile, 'utf8');
+    expect(csv.trim()).to.equal(
+      'ExpressionSet.ApiName,ConstraintModelTag,ConstraintModelTagType,ReferenceObjectId,$Product2ReferenceId,$ProductClassificationName,$ProductRelatedComponentKey'
+    );
+
+    // And the rule-key mapping file is written.
+    const mapping = JSON.parse(
+      await fs.readFile(path.join(workspaceDir, `${CML_API}_RuleKeyMapping.json`), 'utf8')
+    ) as Array<{ ruleKey: string }>;
+    expect(mapping[0].ruleKey).to.equal('SC__autoSilver__collision__CollisionFee');
+  });
+
+  it('surfaces both a skip and an attribute warning (neither is silent)', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tCOLL00000000001', ProductCode: 'collision', Name: 'Collision' },
+          { Id: '01tORPH00000000001', ProductCode: 'orphan', Name: 'Orphan' },
+        ],
+        // Only Collision resolves to a type tag; the orphan leaf has none => that rule is skipped.
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        // Resolves to Collision, but references GhostAttr which is absent from the model => WARN.
+        Id: 'a0p000000000001',
+        Name: 'Ghost Attr Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('GhostAttrFee', [
+          { operator: 'GreaterThan', attributeName: 'GhostAttr', dataType: 'Number', values: ['5'] },
+        ]),
+      },
+      {
+        // Leaf product has no type tag => UNRESOLVED => skipped (reported, not silent).
+        Id: 'a0p000000000002',
+        Name: 'Orphan Fee',
+        ProductPath: '01tROOT00000000001/01tORPH00000000001',
+        RuleDefinition: ruleDefinition('OrphanFee', [
+          { operator: 'GreaterThan', attributeName: 'Limit', dataType: 'Number', values: ['1000'] },
+        ]),
+      },
+    ]);
+
+    const result = await runCommand();
+
+    const warns = warnOutput();
+    // The skip is surfaced as a warning with a clear reason.
+    expect(warns).to.match(/SKIPPED Orphan Fee/);
+    // The absent-attribute warning is surfaced.
+    expect(warns).to.match(/ATTRIBUTE/);
+    expect(warns).to.match(/GhostAttr/);
+
+    // Only the resolvable rule made it into the mapping (the orphan was skipped, not placed).
+    expect(result.ruleKeyMapping).to.have.length(1);
+    expect(result.ruleKeyMapping[0].name).to.equal('Ghost Attr Fee');
+
+    const mergedCml = await fs.readFile(result.cmlFile, 'utf8');
+    expect(mergedCml).to.include('SC__autoSilver__collision__GhostAttrFee');
+    expect(mergedCml).to.not.include('OrphanFee');
+  });
+
+  // ---- M8: the insurance-layer merge-CSV header MUST stay identical to the common util's header.
+  // The constant is duplicated (insurance owns the header-only merge CSV; the common util owns the
+  // build-path CSV). This guard fails if the common header drifts so the divergence can't go silent.
+  it('M8: merge associations header is byte-identical to the common util header', async () => {
+    stubOrgConnection(
+      mockConnection({
+        existingCml: GOLD_CML,
+        productCodes: [
+          { Id: '01tROOT00000000001', ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: '01tCOLL00000000001', ProductCode: 'collision', Name: 'Collision' },
+        ],
+        productTypeTags: [{ ReferenceObjectId: '01tCOLL00000000001', ConstraintModelTag: 'Collision' }],
+      })
+    );
+    await writeSurchargeFile([
+      {
+        Id: 'a0p000000000001',
+        Name: 'Collision Fee',
+        ProductPath: '01tROOT00000000001/01tCOLL00000000001',
+        RuleDefinition: ruleDefinition('CollisionFee', []),
+      },
+    ]);
+
+    const result = await runCommand();
+    const mergeHeader = (await fs.readFile(result.associationsFile, 'utf8')).split('\n')[0];
+
+    // The common util emits its header as the first line of its CSV (with zero associations).
+    const commonHeader = generateCsvForAssociations('ignored', []).split('\n')[0];
+
+    expect(mergeHeader).to.equal(commonHeader);
+  });
+});

--- a/test/shared/insurance/insurance-cml-merge.test.ts
+++ b/test/shared/insurance/insurance-cml-merge.test.ts
@@ -322,6 +322,374 @@ type Collision {
     // The new statement sits before the block's real closing brace (the last `}` in the model).
     expect(newIdx).to.be.lessThan(mergedCml.lastIndexOf('}'));
   });
+
+  // ---- C2: replace must anchor on a real surcharge rule statement carrying THIS key, never on a
+  // bare quoted-key substring that appears inside an unrelated rule / comment / longer key.
+  it('C2: does not clobber an unrelated curated rule that merely quotes this key as a value', () => {
+    // A curated rule whose VALUE slot quotes the incoming key, plus a different action+key. The naive
+    // indexOf('"'+key+'"') matches the value occurrence and overwrites this whole curated line.
+    const model = `
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    rule(label == "SC__autoSilver__auto__collision__FEE", "InsuranceSurchargeRule", "SC__OTHER_KEY", "True");
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'Limit > 1000');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+
+    // The unrelated curated rule survives untouched.
+    expect(mergedCml).to.include('"SC__OTHER_KEY"');
+    expect(mergedCml).to.include('label == "SC__autoSilver__auto__collision__FEE"');
+    // Our key is treated as not-present → inserted as a real statement (not a destructive replace).
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+  });
+
+  it('C2: does not treat a longer key containing this key as a substring as a replace', () => {
+    // Existing statement carries a LONGER key whose text contains our key as a substring. The replace
+    // path must NOT latch onto it; our (shorter) key is genuinely absent → insert.
+    const model = `
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    rule(true, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__FEE_EXTENDED", "True");
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__FEE', 'Collision');
+    const { mergedCml, placements } = mergeSurchargeRules(model, [r]);
+    // The longer pre-existing rule is intact.
+    expect(mergedCml).to.include('"SC__autoSilver__auto__collision__FEE_EXTENDED"');
+    expect(placements[0].status).to.equal('inserted');
+    // Exactly one statement now carries the exact key in the action slot.
+    expect(mergedCml).to.include('"InsuranceSurchargeRule", "SC__autoSilver__auto__collision__FEE", "True"');
+  });
+
+  it('C2: replaces the real surcharge statement for this key when one genuinely exists', () => {
+    const r = rule('SC__autoSilver__auto__collision__CMLCodeAmount1', 'Collision', 'Limit > 9999');
+    const { mergedCml, placements } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(placements[0].status).to.equal('replaced');
+    expect(mergedCml).to.include('rule(Limit > 9999, "InsuranceSurchargeRule"');
+    // Key still appears exactly once (no duplicate).
+    expect(mergedCml.split(r.ruleKey)).to.have.length(2);
+  });
+
+  // ---- H1: two rules in ONE run resolving to the same key → one placed, the other a reported skip.
+  it('H1: flags an intra-run duplicate key as a collision skip rather than silently replacing', () => {
+    const dupKey = 'SC__autoSilver__auto__comprehensive__DUP';
+    const first = { ...rule(dupKey, 'Comprehensive', 'true'), recordName: 'FirstSurcharge' };
+    const second = { ...rule(dupKey, 'Comprehensive', 'Deductible > 50'), recordName: 'SecondSurcharge' };
+    const { placements, skips, mergedCml } = mergeSurchargeRules(GOLD_CML, [first, second]);
+
+    // Only the first is placed; the second is reported (not silently overwriting the first).
+    expect(placements).to.have.length(1);
+    expect(placements[0].rule.recordName).to.equal('FirstSurcharge');
+    expect(skips).to.have.length(1);
+    expect(skips[0].rule.recordName).to.equal('SecondSurcharge');
+    expect(skips[0].reason).to.match(/duplicate/i);
+    // The first record's statement is the one that landed; it was NOT replaced by the second's.
+    expect(mergedCml).to.include('rule(true, "InsuranceSurchargeRule", "' + dupKey + '"');
+    expect(mergedCml).to.not.include('Deductible > 50');
+    expect(mergedCml.split(dupKey)).to.have.length(2);
+  });
+
+  // ---- H2: brace scanner must be comment-aware (a `}` inside // or /* */ must not close the block).
+  it('H2: a commented-out `}` inside the block body does not end the block early', () => {
+    const model = `
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    // a curly here should be ignored }
+    /* and a block comment } too */
+    int Floor = [0];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__NEW', 'Collision');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+    expect(skips).to.have.length(0);
+    expect(placements[0].status).to.equal('inserted');
+    // The rule lands AFTER the real last member (Floor), i.e. before the structural close — not
+    // spliced in right after the commented brace. (Before the fix the scanner counted a comment `}`
+    // as the close and inserted right after `int Limit`, ahead of Floor.)
+    const floorIdx = mergedCml.indexOf('int Floor = [0];');
+    const ruleIdx = mergedCml.indexOf(r.ruleKey);
+    expect(ruleIdx).to.be.greaterThan(floorIdx);
+  });
+
+  it('H2: a `}` inside a comment in a sibling block does not corrupt placement', () => {
+    const model = `
+type Comprehensive {
+    // closing brace in comment }
+    int Deductible = [0, 50, 100];
+}
+
+type Collision {
+    int Limit = [1000, 2000, 5000];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__NEW', 'Collision');
+    const { mergedCml, placements } = mergeSurchargeRules(model, [r]);
+    expect(placements[0].status).to.equal('inserted');
+    const collisionIdx = mergedCml.indexOf('type Collision {');
+    const ruleIdx = mergedCml.indexOf(r.ruleKey);
+    // The rule lands inside the real Collision block (after its header). Before the fix the sibling
+    // Comprehensive comment `}` mis-balanced depth and the Collision block resolved off-target.
+    expect(ruleIdx).to.be.greaterThan(collisionIdx);
+    const limitIdx = mergedCml.indexOf('int Limit = [1000, 2000, 5000];');
+    expect(ruleIdx).to.be.greaterThan(limitIdx);
+  });
+
+  // ---- M1 + M5: duplicate leaf type name. Prefer an unambiguous resolution; if ambiguous, skip.
+  it('M5: skips with a clear reason when more than one block shares the leaf type name', () => {
+    const model = `
+type Collision {
+    int Limit = [1000];
+}
+
+type Collision {
+    int Other = [2000];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__NEW', 'Collision');
+    const { placements, skips } = mergeSurchargeRules(model, [r]);
+    expect(placements).to.have.length(0);
+    expect(skips).to.have.length(1);
+    expect(skips[0].reason).to.match(/ambiguous|multiple|duplicate/i);
+  });
+
+  // ---- H5 + M3: attribute presence check must be scoped to the leaf type block (+ ancestry),
+  // ignoring comments and string literals and unrelated sibling blocks.
+  it('H5: warns when the attribute is present only inside a comment', () => {
+    const model = `
+type Collision {
+    // mentions GhostAttr in a comment only
+    int Limit = [1000];
+}
+`;
+    const r = {
+      ...rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'GhostAttr > 5'),
+      referencedAttributes: ['GhostAttr'],
+    };
+    const { attributeWarnings } = mergeSurchargeRules(model, [r]);
+    expect(attributeWarnings).to.have.length(1);
+    expect(attributeWarnings[0]).to.match(/GhostAttr/);
+  });
+
+  it('M3: warns when the attribute appears only inside a string literal', () => {
+    const model = `
+type Collision {
+    rule(label == "SiblingAttr", "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__OTHER", "True");
+    int Limit = [1000];
+}
+`;
+    const r = {
+      ...rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'SiblingAttr > 5'),
+      referencedAttributes: ['SiblingAttr'],
+    };
+    const { attributeWarnings } = mergeSurchargeRules(model, [r]);
+    expect(attributeWarnings).to.have.length(1);
+    expect(attributeWarnings[0]).to.match(/SiblingAttr/);
+  });
+
+  it('H5: does NOT warn when the attribute is declared inside the leaf block or its `: Parent` ancestry', () => {
+    // Leaf Vehicle declares constraint2 directly; Year is declared in its ancestor Auto
+    // (`type Vehicle : Auto`). Both must resolve via the scoped leaf-plus-ancestry check.
+    const r = {
+      ...rule('SC__autoSilver__auto__vehicle__FEE', 'Vehicle', 'Year > 2000'),
+      referencedAttributes: ['constraint2', 'Year'],
+    };
+    const { attributeWarnings } = mergeSurchargeRules(GOLD_CML, [r]);
+    expect(attributeWarnings).to.have.length(0);
+  });
+
+  // ---- M4: a comment that merely mentions the key must NOT trigger a destructive replace.
+  it('M4: a comment mentioning the key does not trigger a replace of the comment line', () => {
+    const model = `
+type Collision {
+    // historical note: "SC__autoSilver__auto__collision__FEE" was removed
+    int Limit = [1000];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__FEE', 'Collision');
+    const { mergedCml, placements } = mergeSurchargeRules(model, [r]);
+    expect(placements[0].status).to.equal('inserted');
+    // The comment is preserved verbatim.
+    expect(mergedCml).to.include('// historical note: "SC__autoSilver__auto__collision__FEE" was removed');
+  });
+
+  // ---- C2 (block-comment facet): a single-line /* */ block comment that documents the rule shape
+  // with this key in the action-scope slot must NOT be mistaken for a real statement and clobbered.
+  it('C2: a single-line block comment documenting the rule shape does not trigger a replace', () => {
+    const model = `
+type Collision {
+    int Limit = [1000, 2000, 5000];
+    /* example: rule(label == "x", "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__FEE", "True"); */
+    int Deductible = [100, 250];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__FEE', 'Collision', 'Limit > 1000');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+
+    // There is NO real rule statement for this key (only a block-comment mention) → INSERT, not replace.
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+    // The documenting block comment survives verbatim.
+    expect(mergedCml).to.include(
+      '/* example: rule(label == "x", "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__FEE", "True"); */'
+    );
+    // The real inserted statement is present (and is the only action-scope occurrence of the key).
+    expect(mergedCml).to.include(
+      'rule(Limit > 1000, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__FEE", "True");'
+    );
+  });
+
+  // ---- H5 (unresolvable-leaf fallback facet): when the leaf type block is ambiguous (duplicate
+  // declaration) the warning check must not silently widen to the whole model and let a sibling-type
+  // declaration of the attribute suppress a real absent-attribute warning.
+  it('H5: a sibling-only attribute still warns even when the replace path hits an ambiguous leaf type', () => {
+    // Duplicate `type Collision` → collectTypeScopeText returns undefined (ambiguous). An existing
+    // surcharge statement for the key forces the REPLACE path (which runs before type-block resolution).
+    // SneakyAttr is declared ONLY on the unrelated sibling type Helper — never on any Collision block.
+    const model = `
+type Helper { int SneakyAttr = [1]; }
+type Collision {
+    int Limit = [1000];
+    rule(SneakyAttr > 5, "InsuranceSurchargeRule", "SC__x__collision__FEE", "True");
+}
+type Collision { int Other = [2]; }
+`;
+    const r = {
+      ...rule('SC__x__collision__FEE', 'Collision', 'SneakyAttr > 5'),
+      referencedAttributes: ['SneakyAttr'],
+    };
+    const { placements, attributeWarnings } = mergeSurchargeRules(model, [r]);
+
+    // The existing statement is replaced in place...
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('replaced');
+    // ...but SneakyAttr is NOT visible to the Collision leaf (only declared on sibling Helper), so the
+    // absent-attribute warning must still fire. The whole-model fallback must not suppress it.
+    expect(attributeWarnings).to.have.length(1);
+    expect(attributeWarnings[0]).to.match(/SneakyAttr/);
+  });
+
+  // ---- L1: replace happens within the correct block.
+  it('L1: replace targets the statement inside the rule type block, not a same-key mention elsewhere', () => {
+    const model = `
+type Comprehensive {
+    // "SC__autoSilver__auto__collision__CMLCodeAmount1" referenced in a comment here
+    int Deductible = [0];
+}
+
+type Collision {
+    int Limit = [1000];
+    rule(true, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__CMLCodeAmount1", "True");
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__CMLCodeAmount1', 'Collision', 'Limit > 1000');
+    const { mergedCml, placements } = mergeSurchargeRules(model, [r]);
+    expect(placements[0].status).to.equal('replaced');
+    // The Comprehensive comment is untouched; the replace happened in the Collision block.
+    expect(mergedCml).to.include('referenced in a comment here');
+    expect(mergedCml).to.include('rule(Limit > 1000, "InsuranceSurchargeRule"');
+  });
+
+  // ---- M4/L2: CRLF preservation on a replaced line.
+  it('L2: preserves CRLF line endings when replacing a statement line', () => {
+    const crlfModel = [
+      '',
+      'type Collision {',
+      '    int Limit = [1000, 2000, 5000];',
+      '    rule(true, "InsuranceSurchargeRule", "SC__autoSilver__auto__collision__CMLCodeAmount1", "True");',
+      '}',
+      '',
+    ].join('\r\n');
+    const r = rule('SC__autoSilver__auto__collision__CMLCodeAmount1', 'Collision', 'Limit > 1000');
+    const { mergedCml, placements } = mergeSurchargeRules(crlfModel, [r]);
+    expect(placements[0].status).to.equal('replaced');
+    // No bare LF was introduced on the replaced line: every LF in the output is preceded by CR.
+    const bareLf = /(^|[^\r])\n/.exec(mergedCml);
+    expect(bareLf, 'output should not contain a bare LF').to.equal(null);
+    expect(mergedCml).to.include('rule(Limit > 1000, "InsuranceSurchargeRule"');
+  });
+});
+
+describe('buildPathedSurchargeRules (referencedAttributes scoping — M7)', () => {
+  const makeRecord = (id: string, name: string, productPath: string): RuleRecord => ({
+    Id: id,
+    Name: name,
+    ProductPath: productPath,
+  });
+
+  it('M7: excludes attributes whose condition was dropped (unknown operator) from referencedAttributes', () => {
+    // One condition is emittable (Limit relational with a safe literal); the other uses an unknown
+    // operator and is dropped by buildConditionExpression. Its attribute must NOT be reported as
+    // referenced (otherwise it produces a spurious absent-attribute warning downstream).
+    const ruleDef: ParsedRuleDefinition = {
+      name: 'Fee',
+      apiName: 'Fee',
+      productPath: 'p1',
+      ruleCriteria: [
+        {
+          rootObjectId: 'root',
+          conditions: [
+            { operator: 'GreaterThan', attributeName: 'Limit', dataType: 'Number', values: ['1000'] },
+            { operator: 'NoSuchOperator', attributeName: 'DroppedAttr', dataType: 'Number', values: ['5'] },
+          ],
+        },
+      ],
+    };
+    const record = makeRecord('r1', 'Fee', 'p1');
+    const [rule] = buildPathedSurchargeRules(
+      'SC',
+      [{ record, ruleDef }],
+      new Map([['p1', 'autoSilver']]),
+      new Map([['p1', 'AutoSilver']])
+    );
+    expect(rule.referencedAttributes).to.include('Limit');
+    expect(rule.referencedAttributes).to.not.include('DroppedAttr');
+  });
+
+  it('M7: excludes attributes from a hostile-value condition the safe-literal guard dropped', () => {
+    const ruleDef: ParsedRuleDefinition = {
+      name: 'Fee',
+      apiName: 'Fee',
+      productPath: 'p1',
+      ruleCriteria: [
+        {
+          rootObjectId: 'root',
+          conditions: [
+            { operator: 'GreaterThan', attributeName: 'Limit', dataType: 'Number', values: ['1000'] },
+            // Hostile unquoted RHS → buildConditionExpression returns null → attribute dropped.
+            { operator: 'Equals', attributeName: 'Hijacked', dataType: 'Number', values: ['2020) || evil('] },
+          ],
+        },
+      ],
+    };
+    const record = makeRecord('r1', 'Fee', 'p1');
+    const [rule] = buildPathedSurchargeRules(
+      'SC',
+      [{ record, ruleDef }],
+      new Map([['p1', 'autoSilver']]),
+      new Map([['p1', 'AutoSilver']])
+    );
+    expect(rule.referencedAttributes).to.include('Limit');
+    expect(rule.referencedAttributes).to.not.include('Hijacked');
+  });
+});
+
+describe('buildPathedSurchargeRules (stage transition — M6)', () => {
+  it('M6: a ruleDef with an underwritingRuleGroup lands the stage transition in the key', () => {
+    const record: RuleRecord = { Id: 'r1', Name: 'Root', ProductPath: 'p1' };
+    const ruleDef: ParsedRuleDefinition = {
+      name: 'Root',
+      apiName: 'Root',
+      productPath: 'p1',
+      underwritingRuleGroup: { fromStage: 'Draft', toStage: 'Approved', stageTransitionName: 'DraftToApproved' },
+    };
+    const [rule] = buildPathedSurchargeRules('UW', [{ record, ruleDef }], new Map([['p1', 'autoSilver']]), new Map());
+    expect(rule.ruleKey).to.include('__DraftToApproved__');
+    expect(rule.ruleKey).to.equal('UW__autoSilver__DraftToApproved__Root');
+  });
 });
 
 describe('fetchExistingConstraintModel', () => {

--- a/test/shared/insurance/insurance-cml-merge.test.ts
+++ b/test/shared/insurance/insurance-cml-merge.test.ts
@@ -199,6 +199,9 @@ describe('mergeSurchargeRules', () => {
     recordName: ruleKey,
     apiName: ruleKey,
     ruleKey,
+    // Default to a non-empty pathProductCodes so the empty-path guard does not fire in existing
+    // tests. A test that exercises Fix #3 overrides this to [] explicitly.
+    pathProductCodes: ['autoSilver'],
     typeName,
     statement: buildSurchargeRuleStatement(declaration, ruleKey),
     referencedAttributes: [],
@@ -237,6 +240,34 @@ describe('mergeSurchargeRules', () => {
     expect(placements).to.have.length(0);
     expect(skips).to.have.length(1);
     expect(skips[0].reason).to.match(/no CML type tag/);
+  });
+
+  // ---- Fix #3: an empty / whitespace-only ProductPath surcharge must be skipped, NEVER reach the
+  // destructive replace path — even if its degenerate `SC__<apiName>` key coincidentally appears in a
+  // curated line.
+  it('Fix #3: skips a surcharge with empty pathProductCodes and never replaces a coincidentally-keyed curated line', () => {
+    // Curated model carries a single-segment-keyed rule that, with an empty ProductPath, the rule key
+    // would degenerate to: `SC__FEE`. A naive replace would clobber this curated line.
+    const model = `
+type Collision {
+    int Limit = [1000];
+    rule(true, "InsuranceSurchargeRule", "SC__FEE", "True");
+}
+`;
+    const r = {
+      ...rule('SC__FEE', 'Collision', 'Limit > 9999'),
+      pathProductCodes: [], // <-- the malformed input under test
+    };
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+
+    // The surcharge is reported as a skip; no placement was emitted.
+    expect(placements).to.have.length(0);
+    expect(skips).to.have.length(1);
+    expect(skips[0].reason).to.match(/empty ProductPath|non-pathed/i);
+
+    // CRITICAL: the curated line was NOT clobbered — its original `rule(true, ...)` body survives
+    // verbatim, proving the empty-path guard runs BEFORE findSurchargeStatement.
+    expect(mergedCml).to.include('rule(true, "InsuranceSurchargeRule", "SC__FEE", "True");');
   });
 
   it('skips a rule whose resolved type block is absent from the model', () => {
@@ -437,6 +468,39 @@ type Collision {
     expect(ruleIdx).to.be.greaterThan(limitIdx);
   });
 
+  // ---- Fix #1: findTypeBlock must run its anchor regex against the comment-blanked SCAN view, so a
+  // commented-out `type X { ... }` header is not double-counted as a real second declaration that
+  // would otherwise trigger an ambiguity skip.
+  it('Fix #1: a block-commented duplicate type header does not make the real same-named type ambiguous', () => {
+    const model = `
+/* historical:
+   type Collision {
+       int OldLimit = [500];
+   }
+*/
+
+type Collision {
+    int Limit = [1000];
+}
+`;
+    const r = rule('SC__autoSilver__auto__collision__FEE', 'Collision');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+
+    // The block-commented header is ignored: the real Collision block resolves unambiguously and the
+    // rule is inserted into it. Before Fix #1 the regex on raw cml matched twice → ambiguity skip.
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+
+    // The historical comment survives verbatim.
+    expect(mergedCml).to.include('/* historical:');
+    expect(mergedCml).to.include('int OldLimit = [500];');
+    // The new rule landed inside the real Collision block (after `int Limit`).
+    const limitIdx = mergedCml.indexOf('int Limit = [1000];');
+    const newIdx = mergedCml.indexOf(r.ruleKey);
+    expect(newIdx).to.be.greaterThan(limitIdx);
+  });
+
   // ---- M1 + M5: duplicate leaf type name. Prefer an unambiguous resolution; if ambiguous, skip.
   it('M5: skips with a clear reason when more than one block shares the leaf type name', () => {
     const model = `
@@ -591,6 +655,55 @@ type Collision {
     // The Comprehensive comment is untouched; the replace happened in the Collision block.
     expect(mergedCml).to.include('referenced in a comment here');
     expect(mergedCml).to.include('rule(Limit > 1000, "InsuranceSurchargeRule"');
+  });
+
+  // ---- Fix #2: replace must splice ONLY the precise matched statement span (`rule(...);`), not the
+  // entire physical line, so a curated line carrying TWO `rule(...);` statements keeps the unrelated
+  // statement intact.
+  it('Fix #2: replacing one rule on a line with two `rule(...);` statements leaves the other intact', () => {
+    const otherKey = 'SC__autoSilver__auto__collision__OTHER';
+    const targetKey = 'SC__autoSilver__auto__collision__TARGET';
+    const model = `
+type Collision {
+    int Limit = [1000];
+    rule(true, "InsuranceSurchargeRule", "${otherKey}", "True"); rule(true, "InsuranceSurchargeRule", "${targetKey}", "True");
+}
+`;
+    const r = rule(targetKey, 'Collision', 'Limit > 9999');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(model, [r]);
+
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('replaced');
+
+    // The OTHER statement on the same line is preserved verbatim.
+    expect(mergedCml).to.include(`rule(true, "InsuranceSurchargeRule", "${otherKey}", "True");`);
+    // The target statement now carries the new declaration.
+    expect(mergedCml).to.include(`rule(Limit > 9999, "InsuranceSurchargeRule", "${targetKey}", "True");`);
+    // The OTHER key still appears exactly once (not duplicated).
+    expect(mergedCml.split(otherKey)).to.have.length(2);
+    // The target key still appears exactly once (replaced, not duplicated).
+    expect(mergedCml.split(targetKey)).to.have.length(2);
+    // Brace balance preserved.
+    expect((mergedCml.match(/{/g) ?? []).length).to.equal((mergedCml.match(/}/g) ?? []).length);
+  });
+
+  // ---- Fix #4: the INSERT path must splice in the model's dominant line ending (CRLF on a
+  // CRLF-curated model), not a hardcoded `\n` that would mix bare LFs into a CRLF file.
+  it('Fix #4: inserting into a CRLF model uses CRLF for the splice -- output stays byte-clean', () => {
+    const crlfModel = ['', 'type Collision {', '    int Limit = [1000];', '}', ''].join('\r\n');
+    const r = rule('SC__autoSilver__auto__collision__NEW', 'Collision');
+    const { mergedCml, placements, skips } = mergeSurchargeRules(crlfModel, [r]);
+
+    expect(skips).to.have.length(0);
+    expect(placements).to.have.length(1);
+    expect(placements[0].status).to.equal('inserted');
+
+    // No bare LF was introduced anywhere -- every LF in the output is preceded by CR.
+    const bareLf = /(^|[^\r])\n/.exec(mergedCml);
+    expect(bareLf, 'output should not contain a bare LF').to.equal(null);
+    // The newly inserted statement is present.
+    expect(mergedCml).to.include(r.statement);
   });
 
   // ---- M4/L2: CRLF preservation on a replaced line.

--- a/test/shared/insurance/insurance-org.test.ts
+++ b/test/shared/insurance/insurance-org.test.ts
@@ -101,6 +101,34 @@ describe('insurance-org fetchProductCodes', () => {
     expect(map.size).to.equal(0);
     expect(fellBack).to.deep.equal([]);
   });
+
+  it('populates the optional collectNames map with Id -> Name from the same query', async () => {
+    const conn = mockConnection({
+      query: () => ({
+        records: [
+          { Id: ID_A, ProductCode: 'autoSilver', Name: 'Auto Silver' },
+          { Id: ID_B, ProductCode: null, Name: 'Health Plan' },
+        ],
+      }),
+    });
+    const names = new Map<string, string>();
+    const map = await fetchProductCodes(conn, new Set([ID_A, ID_B]), { collectNames: names });
+
+    // The code map is unchanged by the additive option...
+    expect(map.get(ID_A)).to.equal('autoSilver');
+    // ...and Name is captured independently of the ProductCode fallback (ID_B has a null code but a Name).
+    expect(names.get(ID_A)).to.equal('Auto Silver');
+    expect(names.get(ID_B)).to.equal('Health Plan');
+  });
+
+  it('omits a product from collectNames when its Name is null', async () => {
+    const conn = mockConnection({
+      query: () => ({ records: [{ Id: ID_A, ProductCode: 'autoSilver', Name: null }] }),
+    });
+    const names = new Map<string, string>();
+    await fetchProductCodes(conn, new Set([ID_A]), { collectNames: names });
+    expect(names.has(ID_A)).to.equal(false);
+  });
 });
 
 describe('insurance-org quoteSoqlIdList', () => {

--- a/test/shared/insurance/insurance-org.test.ts
+++ b/test/shared/insurance/insurance-org.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026, Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { Connection } from '@salesforce/core';
+import { fetchProductCodes, quoteSoqlIdList } from '../../../src/shared/insurance/insurance-org.js';
+
+/** Minimal mock Connection: only `query` is exercised by fetchProductCodes. No live org. */
+function mockConnection(opts: { query?: (soql: string) => { records: unknown[] } }): Connection {
+  return {
+    query: (soql: string) => Promise.resolve(opts.query ? opts.query(soql) : { records: [] }),
+  } as unknown as Connection;
+}
+
+const ID_A = '01tSB000004V4KKYA0';
+const ID_B = '01tSB000004V4KNYA0';
+
+describe('insurance-org fetchProductCodes', () => {
+  it('maps real ProductCode without recording any fallback (M2)', async () => {
+    const conn = mockConnection({
+      query: () => ({
+        records: [{ Id: ID_A, ProductCode: 'CollisionCode', Name: 'Collision' }],
+      }),
+    });
+    const fellBack: string[] = [];
+    const map = await fetchProductCodes(conn, new Set([ID_A]), { onFallback: (id) => fellBack.push(id) });
+
+    expect(map.get(ID_A)).to.equal('CollisionCode');
+    expect(fellBack).to.deep.equal([]);
+  });
+
+  it('records a fallback signal when ProductCode is null and falls back to Name (M2)', async () => {
+    const conn = mockConnection({
+      query: () => ({
+        records: [{ Id: ID_A, ProductCode: null, Name: 'Collision' }],
+      }),
+    });
+    const fellBack: string[] = [];
+    const map = await fetchProductCodes(conn, new Set([ID_A]), { onFallback: (id) => fellBack.push(id) });
+
+    // Fallback behavior preserved: Name is used so callers don't break...
+    expect(map.get(ID_A)).to.equal('Collision');
+    // ...but the fallback is now observable.
+    expect(fellBack).to.deep.equal([ID_A]);
+  });
+
+  it('records a fallback when both ProductCode and Name are null, falling back to Id (M2)', async () => {
+    const conn = mockConnection({
+      query: () => ({
+        records: [{ Id: ID_A, ProductCode: null, Name: null }],
+      }),
+    });
+    const fellBack: string[] = [];
+    const map = await fetchProductCodes(conn, new Set([ID_A]), { onFallback: (id) => fellBack.push(id) });
+
+    expect(map.get(ID_A)).to.equal(ID_A);
+    expect(fellBack).to.deep.equal([ID_A]);
+  });
+
+  it('records fallbacks per-id, only for the ones missing a ProductCode (M2)', async () => {
+    const conn = mockConnection({
+      query: () => ({
+        records: [
+          { Id: ID_A, ProductCode: 'GoodCode', Name: 'A' },
+          { Id: ID_B, ProductCode: null, Name: 'BName' },
+        ],
+      }),
+    });
+    const fellBack: string[] = [];
+    const map = await fetchProductCodes(conn, new Set([ID_A, ID_B]), { onFallback: (id) => fellBack.push(id) });
+
+    expect(map.get(ID_A)).to.equal('GoodCode');
+    expect(map.get(ID_B)).to.equal('BName');
+    expect(fellBack).to.deep.equal([ID_B]);
+  });
+
+  it('works without the optional onFallback callback (additive signature, no ripple)', async () => {
+    const conn = mockConnection({
+      query: () => ({ records: [{ Id: ID_A, ProductCode: null, Name: 'Collision' }] }),
+    });
+    const map = await fetchProductCodes(conn, new Set([ID_A]));
+    expect(map.get(ID_A)).to.equal('Collision');
+  });
+
+  it('returns an empty map and fires no fallback for an empty / all-invalid id set', async () => {
+    const conn = mockConnection({ query: () => ({ records: [] }) });
+    const fellBack: string[] = [];
+    const map = await fetchProductCodes(conn, new Set(['not-an-id']), { onFallback: (id) => fellBack.push(id) });
+    expect(map.size).to.equal(0);
+    expect(fellBack).to.deep.equal([]);
+  });
+});
+
+describe('insurance-org quoteSoqlIdList', () => {
+  it('keeps only well-formed ids and quotes them', () => {
+    expect(quoteSoqlIdList([ID_A, 'bad', ID_B])).to.equal(`'${ID_A}','${ID_B}'`);
+  });
+});

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -288,6 +288,138 @@ describe('buildConstraintDeclaration', () => {
     };
     expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SU\\"V"');
   });
+
+  // C1 — Equals/NotEquals also emit their RHS UNQUOTED whenever the cmlDataType is non-string
+  // (Number/Currency/Percent/Boolean/Date). The relational-only guard left this open: a hostile
+  // value reaches the curated model verbatim. The guard must key off the unquoted emission path,
+  // not an operator allowlist.
+  it('drops a numeric-typed Equals condition whose value is not a safe numeric literal (C1 injection)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Year', operator: 'Equals', dataType: 'Number', values: ['2020) || evil('] },
+            { attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SUV'] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    // The hostile unquoted Equals is dropped; the safe (string-quoted) Equals survives.
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Model == "SUV"');
+  });
+
+  it('drops a Currency-typed NotEquals condition that forges a rule statement (C1 injection)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            {
+              attributeName: 'Premium',
+              operator: 'NotEquals',
+              dataType: 'Currency',
+              values: ['0) , "InsuranceSurchargeRule", "x", "True"); evil('],
+            },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('true');
+  });
+
+  it('preserves a clean numeric Equals unquoted (C1 regression guard)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Year', operator: 'Equals', dataType: 'Number', values: ['2020'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Year == 2020');
+  });
+
+  it('drops a Boolean-typed Equals whose value is not a bare true/false literal (C1 injection)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'IsActive', operator: 'Equals', dataType: 'Boolean', values: ['true) || x('] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('true');
+  });
+
+  it('preserves a clean Boolean Equals unquoted (C1 regression guard)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'IsActive', operator: 'Equals', dataType: 'Boolean', values: ['true'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('IsActive == true');
+  });
+
+  it('drops a Date-typed Equals whose value is not a bare date literal (C1 injection)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'EffDate', operator: 'Equals', dataType: 'Date', values: ['2020-01-01) || x('] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('true');
+  });
+
+  // H3 — escapeQuotes (out of scope) does not escape backslash, so a string value ending in a
+  // backslash escapes its own closing quote and the following content lands as raw CML. The
+  // insurance layer must reject any string-quoted value containing a backslash.
+  it('drops a string Equals value ending in a backslash (H3 quote break-out)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [
+            { attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['evil\\'] },
+            { attributeName: 'Trim', operator: 'Equals', dataType: 'String', values: [') || hijack(('] },
+          ],
+        },
+      ] as RuleCriteria[],
+    };
+    // The backslash-terminated value is dropped; the (now harmless) second value is still quoted.
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('Trim == ") || hijack(("');
+  });
+
+  it('drops a string Contains value containing a backslash-quote sequence (H3 quote break-out)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Notes', operator: 'Contains', dataType: 'String', values: ['a\\"; bad'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('true');
+  });
+
+  it('preserves a clean string Contains value (H3 regression guard)', () => {
+    const ruleDef = {
+      ruleCriteria: [
+        {
+          rootObjectId: '01t',
+          conditions: [{ attributeName: 'Notes', operator: 'Contains', dataType: 'String', values: ['premium'] }],
+        },
+      ] as RuleCriteria[],
+    };
+    expect(buildConstraintDeclaration(ruleDef)).to.equal('strcontain(Notes, "premium")');
+  });
 });
 
 describe('collectAttributes', () => {
@@ -484,6 +616,73 @@ describe('buildCmlModel', () => {
     const healthType = cmlModel.getType('Health');
     expect(autoType?.attributes.map((a) => a.name)).to.deep.equal(['Model']);
     expect(healthType?.attributes.map((a) => a.name)).to.deep.equal(['Deductible']);
+  });
+
+  // H4 — attributes must be declared with their real CML type so that relational comparisons
+  // (which emit a bare numeric RHS, e.g. `Age < 60`) type-check on import. Declaring everything
+  // as `string` produces `string Age; ... Age < 60`, which the CML compiler rejects.
+  it('declares a numeric attribute with its real CML type, not string (H4)', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'Rule1', 'p1'),
+        ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [{ attributeName: 'Age', operator: 'LessThan', dataType: 'Number', values: ['60'] }],
+          },
+        ]),
+      },
+    ];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'UW', 'Test');
+    const ageAttr = cmlModel.getType('autoSilver')?.attributes.find((a) => a.name === 'Age');
+    expect(ageAttr?.type).to.equal('int');
+  });
+
+  it('declares a Boolean attribute as boolean and a string attribute as string (H4)', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'Rule1', 'p1'),
+        ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [
+              { attributeName: 'IsActive', operator: 'Equals', dataType: 'Boolean', values: ['true'] },
+              { attributeName: 'Model', operator: 'Equals', dataType: 'String', values: ['SUV'] },
+            ],
+          },
+        ]),
+      },
+    ];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'UW', 'Test');
+    const attrs = cmlModel.getType('autoSilver')?.attributes ?? [];
+    expect(attrs.find((a) => a.name === 'IsActive')?.type).to.equal('boolean');
+    expect(attrs.find((a) => a.name === 'Model')?.type).to.equal('string');
+  });
+
+  it('falls back to string when an attribute appears with conflicting dataTypes (H4)', () => {
+    const ruleDefs = [
+      {
+        record: makeRecord('r1', 'Rule1', 'p1'),
+        ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [{ attributeName: 'Score', operator: 'GreaterThan', dataType: 'Number', values: ['10'] }],
+          },
+        ]),
+      },
+      {
+        record: makeRecord('r2', 'Rule2', 'p1'),
+        ruleDef: makeRuleDef('Rule2', 'Rule2', 'p1', [
+          {
+            rootObjectId: 'p1',
+            conditions: [{ attributeName: 'Score', operator: 'Equals', dataType: 'String', values: ['high'] }],
+          },
+        ]),
+      },
+    ];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'UW', 'Test');
+    const scoreAttr = cmlModel.getType('autoSilver')?.attributes.find((a) => a.name === 'Score');
+    expect(scoreAttr?.type).to.equal('string');
   });
 
   it('falls back to product ID when code is not in map', () => {

--- a/test/shared/insurance/insurance-rule-generator.test.ts
+++ b/test/shared/insurance/insurance-rule-generator.test.ts
@@ -22,6 +22,7 @@ import {
   collectAttributes,
   decodeHtmlEntities,
   generateRuleKey,
+  isSafeAssociationReferenceValue,
   sanitizeName,
 } from '../../../src/shared/insurance/insurance-rule-generator.js';
 import { ParsedRuleDefinition, RuleCriteria, RuleRecord } from '../../../src/shared/insurance/models.js';
@@ -540,6 +541,43 @@ describe('buildCmlModel', () => {
     expect(cmlModel.associations[0].referenceObjectId).to.equal('p1');
   });
 
+  // The common `cml import as-expression-set` resolves a Type association's Product2 by NAME
+  // (`SELECT Id, Name FROM Product2 WHERE Name IN (<$Product2ReferenceId>)`), then keys the lookup
+  // off that same value. convert must therefore emit the product Name — not its ProductCode — into
+  // the association reference value, or the importer finds no match and silently drops the
+  // association (the Type block imports with zero Product2 bindings and never evaluates).
+  it('emits the product Name (not the ProductCode) as the association reference value when a name map is provided', () => {
+    const ruleDefs = [{ record: makeRecord('r1', 'Rule1', 'p1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1') }];
+    const { cmlModel } = buildCmlModel(
+      ruleDefs,
+      new Map([['p1', 'autoSilver']]),
+      'SC',
+      'Test',
+      undefined,
+      new Map([['p1', 'Auto Silver']])
+    );
+
+    expect(cmlModel.associations).to.have.length(1);
+    // The tag / CML type name stay ProductCode-derived (the CML doc keys off them)...
+    expect(cmlModel.associations[0].tag).to.equal('autoSilver');
+    // ...but $Product2ReferenceId — what the importer resolves by — must be the product Name.
+    expect(cmlModel.associations[0].referenceObjectReferenceValue).to.equal('Auto Silver');
+  });
+
+  it('falls back to the ProductCode reference value when the name map has no entry for the product', () => {
+    const ruleDefs = [{ record: makeRecord('r1', 'Rule1', 'p1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1') }];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'SC', 'Test', undefined, new Map());
+
+    expect(cmlModel.associations[0].referenceObjectReferenceValue).to.equal('autoSilver');
+  });
+
+  it('preserves the legacy ProductCode reference value when no name map is passed (backward compatible)', () => {
+    const ruleDefs = [{ record: makeRecord('r1', 'Rule1', 'p1'), ruleDef: makeRuleDef('Rule1', 'Rule1', 'p1') }];
+    const { cmlModel } = buildCmlModel(ruleDefs, new Map([['p1', 'autoSilver']]), 'SC', 'Test');
+
+    expect(cmlModel.associations[0].referenceObjectReferenceValue).to.equal('autoSilver');
+  });
+
   it('generates surcharge ruleKey with 3 segments', () => {
     const ruleDefs = [{ record: makeRecord('r1', 'MyRule', 'p1'), ruleDef: makeRuleDef('MyRule', 'MyRule', 'p1') }];
     const productMap = new Map([['p1', 'autoSilver']]);
@@ -789,6 +827,34 @@ describe('discoverCmlApiByProducts', () => {
     const conn = mockConnection({});
     const result = await discoverCmlApiByProducts(conn, new Set());
     expect(result).to.be.undefined;
+  });
+});
+
+describe('isSafeAssociationReferenceValue', () => {
+  it('accepts ordinary product names, including spaces', () => {
+    expect(isSafeAssociationReferenceValue('Auto Silver')).to.equal(true);
+    expect(isSafeAssociationReferenceValue('autoSilver')).to.equal(true);
+    expect(isSafeAssociationReferenceValue('Health Plan 2026')).to.equal(true);
+  });
+
+  // The reference value is written into a naive comma-joined CSV column AND, downstream, into the
+  // importer's single-quoted SOQL `WHERE Name IN ('<value>')`. A comma shifts the CSV column; a
+  // single/double quote, backslash, or newline breaks out of the CSV cell or the SOQL literal.
+  it('rejects a comma (would shift the CSV column)', () => {
+    expect(isSafeAssociationReferenceValue('Auto, Silver')).to.equal(false);
+  });
+
+  it('rejects quotes, backslash, and newlines (CSV / SOQL break-out)', () => {
+    expect(isSafeAssociationReferenceValue("O'Brien")).to.equal(false);
+    expect(isSafeAssociationReferenceValue('a"b')).to.equal(false);
+    expect(isSafeAssociationReferenceValue('a\\b')).to.equal(false);
+    expect(isSafeAssociationReferenceValue('a\nb')).to.equal(false);
+    expect(isSafeAssociationReferenceValue('a\rb')).to.equal(false);
+  });
+
+  it('rejects an empty / whitespace-only value', () => {
+    expect(isSafeAssociationReferenceValue('')).to.equal(false);
+    expect(isSafeAssociationReferenceValue('   ')).to.equal(false);
   });
 });
 


### PR DESCRIPTION
## What

Hardens the Insurance surcharge→CML **merge** path (`cml convert surcharge-rules`) against the 21 findings raised in the adversarial review of #167 (now merged). All changes are confined to `src/shared/insurance/**` plus their tests; no common/shared emitter files were touched.

## Why

The merge nests generated `rule(...)` statements into a hand-curated "Gold Standard" `ConstraintModel`. The review found ways an attacker-influenced surcharge value or an unlucky model layout could **inject CML**, **clobber the wrong statement**, or produce **silently-wrong output** that imports cleanly but never fires.

## Findings fixed (21)

**Critical**
- **C1** — Unquoted, attacker-influenced RHS on relational / non-string equality operators could reach the curated model verbatim. Replaced the operator-allowlist guard with an **emission-path guard**: any value on an unquoted-emission condition must be a bare safe literal (numeric/boolean/strict-ISO-date), else the condition is dropped.
- **C2** — Substring `indexOf('"'+ruleKey+'"')` replace could match inside a comment/string. Now anchors to the real `rule(...,"InsuranceSurchargeRule","<key>",...)` statement via a regex over a length-preserving comment-blanked copy.

**High** — H1 (duplicate-key skip), H2 (brace-balance state machine), H3 (backslash can't break out of a quoted literal), H4 (real per-attribute CML types, conflict→STRING), H5 (attribute-warning scoped to the leaf type; fail-visible when unresolvable), H6, H7.

**Medium / Low** — M1–M8, L1, L2 (ambiguous-type guard, CRLF preservation, header-parity guard, no-ProductCode fallback warning, emitted-vs-collected attribute parity, etc.).

## Evidence (local gate, Node 20)

- `yarn build` clean · eslint clean (1 pre-existing out-of-scope warning) · `mocha` **146 passing, 0 failing** · `snapshot:compare` clean.
- New/expanded exploit + regression tests for every finding, including the repair-round block-comment C2 case and the unresolvable-leaf H5 case.

## Caveats for the reviewer

1. **C2 and H5** were flagged as bypassed on the first adversarial pass, fixed in repair round 1, and now pass the full gate — but were **not re-run through the adversarial verifiers**. Their closure evidence is the new tests + green suite, not a fresh refutation.
2. The true root cause behind C1/H3 also lives in the **out-of-scope** shared emitter `cml-operators.ts` (unquoted non-string RHS; `escapeQuotes` does not escape backslash). This PR defends at the insurance boundary; the shared-emitter gap should be flagged to its owners separately.

All org interaction in tests uses a mock `Connection`; nothing here writes to a live model.



---

Work item: @W-23217457@
